### PR TITLE
Unpublish pg port to avoid collision & restrict Grafana port to 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,6 @@ services:
       - ./postgres_cfg/postgresql.conf:/etc/postgresql/postgresql.conf
       - ./postgres_cfg/db.sql:/docker-entrypoint-initdb.d/db.sql
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
-    ports:
-      - 5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-d", "db_prod"]
       interval: 30s
@@ -119,8 +117,6 @@ services:
     volumes:
       - ./monitoring/configuration/postgres-exporter.yml:/etc/pgexporter/postgres-exporter.yml
       - ./monitoring/configuration/pg-exporter-queries.yml:/etc/pgexporter/queries.yml
-    ports:
-      - 9187:9187
     command:
       # Both the config file and 'DATA_SOURCE_NAME' should contain valid connection info
       - --config.file=/etc/pgexporter/postgres-exporter.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - ./monitoring/configuration/customizations/custom-logo.svg:/usr/share/grafana/public/img/grafana_typelogo.svg:Z
       - ./monitoring/configuration/customizations/custom-logo.png:/usr/share/grafana/public/img/fav32.png:Z
     ports:
-      - 3000:3000
+      - 127.0.0.1:3000:3000
     restart: on-failure
     depends_on:
       - prometheus


### PR DESCRIPTION

- Avoid exposing postgres ports as they might collide with a running PG instance
  This comes from @vpavlin 's advice given that kind of port collisions are quite likely to happen.

- Restrict the grafana's port to be accessible only from localhost so that it is aligned with the comment in the README.md.