### PR TITLE
feat: add support for WSS, nodekey and extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Go to [http://localhost:3000/d/yns_4vFVk/nwaku-monitoring?orgId=1](http://localh
 Notes:
 * Feel free to change the image you are using `statusteam/nim-waku:xxx`. You can see the available tags in [docker hub](https://hub.docker.com/r/statusteam/nim-waku).
 * If you want to access grafana from outside your machine, feel free to remove `127.0.0.1` and open the port, but in that case you may want to set up a password to your grafana.
+
+## Configuration
+
+There are multiple environment variables you can configure to modify behaviour of the Waku node:
+
+* `NWAKU_IMAGE` - the image you want to use for the nwaku container (e.g. `NWAKU_IMAGE=statusteam/nim-waku:v0.19.0-rc.0`)
+* `DOMAIN` - domain name pointing to the IP address of your node, when configured the run script will request SSL certs from Let's Encrypt and run Waku node with WebSockets Secure (WSS) options enabled (e.g. `DOMAIN=waku.example.com`)
+* `NODEKEY` - this env variable allows you to provide a node key as described in [operators documentation](https://github.com/waku-org/nwaku/blob/master/docs/operators/how-to/configure-key.md) (e.g. `NODEKEY=9f439983aa4851346cfe6e17585e426f482871a43626812e23490895cd602c11`)
+* `EXTRA_ARGS` - this variable allows you to specify additional or overriding CLI option for the Waku node which will be appended to the `wakunode2` command. (e.g. `EXTRA_ARGS="--store=false --max-connections=3000`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ x-pg-pass: &pg_pass ${POSTGRES_PASSWORD:-test123}
 x-pg-user: &pg_user ${POSTGRES_USER:-postgres}
 
 x-pg-environment: &pg_env
-  environment:
     POSTGRES_USER: *pg_user
     POSTGRES_PASSWORD: *pg_pass
 
@@ -42,7 +41,7 @@ services:
     # For a pre-built release. See available releases:
     # github.com/waku-org/nwaku/releases
 
-    image: statusteam/nim-waku:v0.19.0-rc.0
+    image: ${NWAKU_IMAGE:-statusteam/nim-waku:v0.19.0}
     restart: on-failure
     ports:
       - 30304:30304/tcp
@@ -50,11 +49,18 @@ services:
       - 127.0.0.1:8545:8545/tcp
       - 9005:9005/udp
       - 127.0.0.1:8003:8003
+      - 80:80 #Let's Encrypt
+      - 8000:8000/tcp #WSS
     <<:
       - *logging
-      - *pg_env
+    environment:
+      DOMAIN: ${DOMAIN}
+      NODEKEY: ${NODEKEY}
+      EXTRA_ARGS: ${EXTRA_ARGS}
+      <<: *pg_env
     volumes:
       - ./run_node.sh:/opt/run_node.sh:Z
+      - ./certs:/etc/letsencrypt/:Z
     entrypoint: sh
     command:
       - /opt/run_node.sh
@@ -97,13 +103,14 @@ services:
     # and the store-message-db-url is set to use Postgres
     image: postgres:alpine3.18
     restart: on-failure
-    <<: *pg_env
+    environment:
+      <<: *pg_env
     volumes:
-      - ./postgres_cfg/postgresql.conf:/etc/postgresql/postgresql.conf
-      - ./postgres_cfg/db.sql:/docker-entrypoint-initdb.d/db.sql
+      - ./postgres_cfg/postgresql.conf:/etc/postgresql/postgresql.conf:Z
+      - ./postgres_cfg/db.sql:/docker-entrypoint-initdb.d/db.sql:Z
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "db_prod"]
+      test: ["CMD-SHELL", "pg_isready -d db_prod"]
       interval: 30s
       timeout: 60s
       retries: 5
@@ -115,8 +122,8 @@ services:
     restart: on-failure
     <<: *pg_exp_env
     volumes:
-      - ./monitoring/configuration/postgres-exporter.yml:/etc/pgexporter/postgres-exporter.yml
-      - ./monitoring/configuration/pg-exporter-queries.yml:/etc/pgexporter/queries.yml
+      - ./monitoring/configuration/postgres-exporter.yml:/etc/pgexporter/postgres-exporter.yml:Z
+      - ./monitoring/configuration/pg-exporter-queries.yml:/etc/pgexporter/queries.yml:Z
     command:
       # Both the config file and 'DATA_SOURCE_NAME' should contain valid connection info
       - --config.file=/etc/pgexporter/postgres-exporter.yml


### PR DESCRIPTION
This PR adds a few features to the nwaku-compose, which, I believe, makes it a bit more "production ready"

1. Enabling WSS by defining `DOMAIN` environment variable - it uses Let's Encrypt to obtain SSL certificates and stores them in a volume to make sure you don't hit the LE rate limits
2. You can define `NODEKEY` variable which then uses the value as a `--nodekey` option
3. You can define `EXTRA_ARGS` variable to override or add options in `run_node.sh`

Additional changes in the compose file:
* Update to latest nwaku image
* Openning ports 80 and 8000 for Let's Encrypt challenge and WSS
* Tweaking the env var anchor for extendability
* Making the compose work with podman-compose (adding missing Z options and changing the format of healthcheck command)