### PR TITLE
docker-compose.yml: hard-code PG version to 15.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
   postgres:
     # This service is used when the Waku node has the 'store' protocol enabled
     # and the store-message-db-url is set to use Postgres
-    image: postgres:alpine3.18
+    image: postgres:15.4-alpine3.18
     restart: on-failure
     environment:
       <<: *pg_env


### PR DESCRIPTION
This is needed to avoid unwanted automatic version upgrades by just using the "latest" image: `postgres:alpine3.18`.