### PR TITLE
update wakuv2 fleet DNS discovery enrtree

### DIFF
--- a/run_node.sh
+++ b/run_node.sh
@@ -51,7 +51,7 @@ exec /usr/bin/wakunode\
   --keep-alive=true\
   --max-connections=150\
   --dns-discovery=true\
-  --dns-discovery-url=enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im\
+  --dns-discovery-url=enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im\
   --discv5-discovery=true\
   --discv5-udp-port=9005\
   --discv5-enr-auto-update=True\


### PR DESCRIPTION
Enrtrees were regenerated. Need to update the old one.
DNS discoverty should continue to work.
