### PR TITLE
Chore handle docker compose failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,30 @@ There are multiple environment variables you can configure to modify behaviour o
 * `DOMAIN` - domain name pointing to the IP address of your node, when configured the run script will request SSL certs from Let's Encrypt and run Waku node with WebSockets Secure (WSS) options enabled (e.g. `DOMAIN=waku.example.com`)
 * `NODEKEY` - this env variable allows you to provide a node key as described in [operators documentation](https://github.com/waku-org/nwaku/blob/master/docs/operators/how-to/configure-key.md) (e.g. `NODEKEY=9f439983aa4851346cfe6e17585e426f482871a43626812e23490895cd602c11`)
 * `EXTRA_ARGS` - this variable allows you to specify additional or overriding CLI option for the Waku node which will be appended to the `wakunode2` command. (e.g. `EXTRA_ARGS="--store=false --max-connections=3000`)
+
+## Log monitoring and troubleshooting
+
+When running the container in detached mode, it's important to note that while notifications about successful container startup are received, any errors occurring during runtime won't be printed to the terminal.
+
+To ensure the proper functioning of the container, it is strongly recommended to monitor the logs. Pay special attention during the first minute of runtime to confirm that the node has spun up successfully.
+
+To check the status of the node, visit [http://localhost:8003/health](http://localhost:8003/health)
+
+For real-time logs of the 'nwaku' service, use the following command:
+
+```console
+docker-compose logs nwaku -f
+```
+
+In general, to view logs of any service running on Docker Compose, execute:
+
+```console
+docker-compose logs <service> -f
+```
+
+To identify different services currently running, refer to the "SERVICE" column displayed when executing:
+```console
+docker-compose ps
+```
+
+![services](https://i.ibb.co/ZXG3Ld9/image.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     # github.com/waku-org/nwaku/releases
 
     image: ${NWAKU_IMAGE:-statusteam/nim-waku:v0.20.0}
-    restart: on-failure
+    restart: on-failure:5 # Retry up to 5 times
     ports:
       - 30304:30304/tcp
       - 30304:30304/udp
@@ -75,7 +75,7 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
     ports:
       - 127.0.0.1:9090:9090
-    restart: on-failure
+    restart: on-failure:5
     depends_on:
       - postgres-exporter
       - nwaku
@@ -94,7 +94,7 @@ services:
       - ./monitoring/configuration/customizations/custom-logo.png:/usr/share/grafana/public/img/fav32.png:Z
     ports:
       - 127.0.0.1:3000:3000
-    restart: on-failure
+    restart: on-failure:5
     depends_on:
       - prometheus
 
@@ -102,7 +102,7 @@ services:
     # This service is used when the Waku node has the 'store' protocol enabled
     # and the store-message-db-url is set to use Postgres
     image: postgres:15.4-alpine3.18
-    restart: on-failure
+    restart: on-failure:5
     environment:
       <<: *pg_env
     volumes:
@@ -119,7 +119,7 @@ services:
   postgres-exporter:
     # Service aimed to scrape information from Postgres and post it to Prometeus
     image: quay.io/prometheuscommunity/postgres-exporter:v0.12.0
-    restart: on-failure
+    restart: on-failure:5
     <<: *pg_exp_env
     volumes:
       - ./monitoring/configuration/postgres-exporter.yml:/etc/pgexporter/postgres-exporter.yml:Z


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewrs -->
Set a maximum amount of 5 retries after container failure, to avoid case of infinitely restarting services in case of configuration failure.

Added section to README.md instructing users how to monitor logs, taking into account that when running on detached mode users are not notified if a container fails during runtime.

# Changes

<!-- List of detailed changes -->

- [x] Set a maximum amount of 5 retries after container failure
- [x] Added section to README.md instructing users how to monitor logs

<!--
## How to test

1.
1.
1.

-->


## Issue

closes [#2064](https://github.com/waku-org/nwaku/issues/2064)
