### PR TITLE
fix: use volume for PG data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
     volumes:
       - ./postgres_cfg/postgresql.conf:/etc/postgresql/postgresql.conf:Z
       - ./postgres_cfg/db.sql:/docker-entrypoint-initdb.d/db.sql:Z
+      - ${PG_DATA_DIR:-./postgresql}:/var/lib/postgresql/data:Z
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d db_prod"]


### PR DESCRIPTION
I believe I raised this in the inital postgres PR, but it sliped in without the volume:)

Not using volume has a few issues:
* every new container creation will result in empty DB (i.e. bad for Store?)
* since the PG is stored **inside** of the container, unless it is cleaned, it may polute the server/machine file system
* it'll be easier to control how much data is taken by PG than relying on the container overlay filesystem (you can easily attach additional storage and point to that rather than using rootfs of the machine)