### PR TITLE
fix: correcting readme logs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ To check the status of the node, visit [http://localhost:8003/health](http://loc
 For real-time logs of the 'nwaku' service, use the following command:
 
 ```console
-docker-compose logs nwaku -f
+docker-compose logs -f nwaku
 ```
 
 In general, to view logs of any service running on Docker Compose, execute:
 
 ```console
-docker-compose logs <service> -f
+docker-compose logs -f <service>
 ```
 
 To identify different services currently running, refer to the "SERVICE" column displayed when executing:


### PR DESCRIPTION
The example command `docker-compose logs <service> -f` works on my local machine and added it to the readme based on that behavior.

However, when using a different machine I got an error, probably due to a different docker-compose version.
Updating the command to `docker-compose logs -f <service>` which is the correct syntax by the documentation.