### PR TITLE
register_rln.sh: explicitly setting keystore folder in current folder

### DIFF
--- a/register_rln.sh
+++ b/register_rln.sh
@@ -12,6 +12,6 @@ docker run -v ./keystore:/keystore/:Z quay.io/wakuorg/nwaku-pr:2189 generateRlnK
 --rln-relay-eth-client-address=$ETH_CLIENT_ADDRESS \
 --rln-relay-eth-private-key=$ETH_TESTNET_KEY \
 --rln-relay-eth-contract-address=0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4 \
---rln-relay-cred-path=/keystore/keystore.json \
+--rln-relay-cred-path=./keystore/keystore.json \
 --rln-relay-cred-password=$KEYSTORE_PASSWORD \
 --execute


### PR DESCRIPTION
This is needed to make it clearer that the "keystore" folder is created in the current folder rather than in /

Therefore, we will have the next log (see the "path" component :)
```
INF 2023-11-08 08:38:25.847+00:00 credentials persisted                      topics="rln_keystore_generator" tid=1 file=rln_keystore_generator.nim:95 path=./keystore/keystore.json
```

Instead of the following, which can be misunderstood as being stored in `/`:
```
INF 2023-11-08 08:09:01.951+00:00 credentials persisted                      topics="rln_keystore_generator" tid=1 file=rln_keystore_generator.nim:95 path=/keystore/keystore.json
```

Also, most importantly, I found permission issues because the script was trying to create it in the root folder (/)
```
ERR 2023-11-08 08:03:48.588+00:00 failed to persist credentials              topics="rln_keystore_generator" tid=1 file=rln_keystore_generator.nim:92 error="keystore error: OS specific error: Cannot open file for writing"
```