### PR TITLE
fix: using full path for RLN keystore

### DIFF
--- a/register_rln.sh
+++ b/register_rln.sh
@@ -8,7 +8,7 @@ fi
 
 # TODO: Set nwaku release when ready instead of quay
 
-docker run -v ./keystore:/keystore/:Z quay.io/wakuorg/nwaku-pr:2189 generateRlnKeystore \
+docker run -v $pwd/keystore:/keystore/:Z quay.io/wakuorg/nwaku-pr:2189 generateRlnKeystore \
 --rln-relay-eth-client-address=$ETH_CLIENT_ADDRESS \
 --rln-relay-eth-private-key=$ETH_TESTNET_KEY \
 --rln-relay-eth-contract-address=0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4 \


### PR DESCRIPTION
Using full keystore path to avoid the following error encountered on WSL2 Ubuntu on Windows

![image](https://github.com/waku-org/nwaku-compose/assets/101006718/aecce984-3287-4de6-9806-116bf7a22aae)
