### PR TITLE
feat: add support for .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/<key>
+ETH_TESTNET_KEY=012345privatekey
+RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/<key>
 ETH_TESTNET_KEY=012345privatekey
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"
+NODEKEY=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/<key>
 ETH_TESTNET_KEY=012345privatekey
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"
+
+# Advanced
+NWAKU_IMAGE=
 NODEKEY=
+DOMAIN=
+EXTRA_ARGS=
+RLN_RELAY_CONTRACT_ADDRESS=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 keystore
 postgresql
 rln_tree
+.env

--- a/README.md
+++ b/README.md
@@ -14,10 +14,18 @@ You need:
 * Ethereum Sepolia account with some balance <0.01 Eth. Get some [here](https://www.infura.io/faucet/sepolia).
 * A password to protect your rln membership.
 
+You can either export the environment variable (keep in mind that this will expose your secrets in your shell history)
+
 ```
 export ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/YOUR_INFURA_KEY
 export ETH_TESTNET_KEY=REPLACE_BY_YOUR_KEY
 export RLN_RELAY_CRED_PASSWORD=PICK_A_PASSWORD
+```
+
+Or you can use `.env` file - copy the example and edit the variables inside
+
+```
+cp .env.example .env
 ```
 
 **🔑 1. Register RLN membership**

--- a/README.md
+++ b/README.md
@@ -14,19 +14,14 @@ You need:
 * Ethereum Sepolia account with some balance <0.01 Eth. Get some [here](https://www.infura.io/faucet/sepolia).
 * A password to protect your rln membership.
 
-You can either export the environment variable (keep in mind that this will expose your secrets in your shell history)
-
-```
-export ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/YOUR_INFURA_KEY
-export ETH_TESTNET_KEY=REPLACE_BY_YOUR_KEY
-export RLN_RELAY_CRED_PASSWORD=PICK_A_PASSWORD
-```
-
-Or you can use `.env` file - copy the example and edit the variables inside
+There is `.env.example` available for you as a template to use for providing the above values. The process when working with `.env` files is to copy the `.env.example`, store it as `.env` and edit the values there.
 
 ```
 cp .env.example .env
+${EDITOR} .env
 ```
+
+Make sure to **NOT** place any secrets into `.env.example`, as they might be unintentionally published in the Git repository.
 
 **🔑 1. Register RLN membership**
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You need:
 ```
 export ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/YOUR_INFURA_KEY
 export ETH_TESTNET_KEY=REPLACE_BY_YOUR_KEY
-export KEYSTORE_PASSWORD=PICK_A_PASSWORD
+export RLN_RELAY_CRED_PASSWORD=PICK_A_PASSWORD
 ```
 
 **🔑 1. Register RLN membership**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       NODEKEY: ${NODEKEY}
-      KEYSTORE_PASSWORD: ${KEYSTORE_PASSWORD}
+      KEYSTORE_PASSWORD: "${KEYSTORE_PASSWORD}"
       ETH_CLIENT_ADDRESS: *eth_client_address
       EXTRA_ARGS: ${EXTRA_ARGS}
       <<:
@@ -119,8 +119,8 @@ services:
       - ./postgres_cfg/db.sql:/docker-entrypoint-initdb.d/db.sql:Z
       - ${PG_DATA_DIR:-./postgresql}:/var/lib/postgresql/data:Z
     command: postgres -c config_file=/etc/postgresql/postgresql.conf
-    ports:
-      - 127.0.0.1:5432:5432
+    ports: []
+    #  - 127.0.0.1:5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d db_prod"]
       interval: 30s

--- a/register_rln.sh
+++ b/register_rln.sh
@@ -1,17 +1,24 @@
 #!/bin/sh
 
-if test -f ./keystore/keystore.json; then
+if test -f $(pwd)/keystore/keystore.json; then
   echo "keystore/keystore.json alredy exists. Use it instead of creating a new one."
   echo "Exiting"
   exit 1
 fi
 
+if test -f .env; then
+  echo "Using .env file"  
+  . $(pwd)/.env
+fi
+
 # TODO: Set nwaku release when ready instead of quay
+
+
 
 docker run -v $(pwd)/keystore:/keystore/:Z wakuorg/nwaku:v0.21.3 generateRlnKeystore \
 --rln-relay-eth-client-address=${ETH_CLIENT_ADDRESS} \
 --rln-relay-eth-private-key=${ETH_TESTNET_KEY} \
 --rln-relay-eth-contract-address=0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4 \
 --rln-relay-cred-path=/keystore/keystore.json \
---rln-relay-cred-password=${KEYSTORE_PASSWORD} \
+--rln-relay-cred-password="'"${RLN_RELAY_CRED_PASSWORD}"'" \
 --execute

--- a/run_node.sh
+++ b/run_node.sh
@@ -46,12 +46,12 @@ if [ -n "${NODEKEY}" ]; then
     NODEKEY=--nodekey=${NODEKEY}
 fi
 
-if [ -n "${RLN_RELAY_CRED_PATH}" ]; then
-    RLN_RELAY_CRED_PATH=--rln-relay-cred-path=${RLN_RELAY_CRED_PATH}
-fi
+
+RLN_RELAY_CRED_PATH=--rln-relay-cred-path=${RLN_RELAY_CRED_PATH:-/keystore/keystore.json}
+
 
 if [ -n "${RLN_RELAY_CRED_PASSWORD}" ]; then
-    RLN_RELAY_CRED_PASSWORD=--rln-relay-cred-password=${RLN_RELAY_CRED_PASSWORD}
+    RLN_RELAY_CRED_PASSWORD=--rln-relay-cred-password="'"${RLN_RELAY_CRED_PASSWORD}"'"
 fi
 
 exec /usr/bin/wakunode\
@@ -95,8 +95,6 @@ exec /usr/bin/wakunode\
   --rln-relay-eth-contract-address="${RLN_RELAY_CONTRACT_ADDRESS}"\
   --rln-relay-eth-client-address="${ETH_CLIENT_ADDRESS}"\
   --rln-relay-tree-path="/etc/rln_tree"\
-  --rln-relay-cred-password="${KEYSTORE_PASSWORD}"\
-  --rln-relay-cred-path="/keystore/keystore.json"\
   ${RLN_RELAY_CRED_PATH}\
   ${RLN_RELAY_CRED_PASSWORD}\
   ${DNS_WSS_CMD}\


### PR DESCRIPTION
This PR adds support for `.env` for registration and running docker-compose

It also removes the PG port exposure (let me know if I should submit it as a separate PR)

It also tweaks the shell scripts a bit, but there should be no change in behaviour