### PR TITLE
Add row count and database size panels

### DIFF
--- a/monitoring/configuration/dashboards/nwaku-monitoring.json
+++ b/monitoring/configuration/dashboards/nwaku-monitoring.json
@@ -86,7 +86,7 @@
         "showUnfilled": true,
         "valueMode": "color"
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -153,9 +153,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -215,9 +216,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -281,9 +283,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -542,7 +545,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -620,9 +623,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -697,9 +701,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -762,9 +767,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -840,9 +846,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -905,9 +912,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -967,9 +975,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1032,9 +1041,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -1094,9 +1104,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -2653,9 +2664,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -2764,9 +2776,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -2876,9 +2889,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -2915,6 +2929,20 @@
         }
       ],
       "valueName": "current"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 67
+      },
+      "id": 140,
+      "libraryPanel": {
+        "name": "Rows in message table (Postgres)",
+        "uid": "e2941e53-8bdf-4e44-8a14-8cca6476c269"
+      },
+      "title": "Rows in message table (Postgres)"
     },
     {
       "datasource": "Prometheus",
@@ -2956,8 +2984,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 4,
-        "x": 12,
+        "w": 3,
+        "x": 15,
         "y": 67
       },
       "id": 16,
@@ -2976,7 +3004,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(pg_stat_database_blks_hit{instance=~\"$Instance\"})/(sum(pg_stat_database_blks_hit{instance=~\"$Instance\"})+sum(pg_stat_database_blks_read{instance=~\"$Instance\"}))*100",
@@ -3026,8 +3054,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 4,
-        "x": 16,
+        "w": 3,
+        "x": 18,
         "y": 67
       },
       "id": 9,
@@ -3046,7 +3074,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(pg_stat_database_numbackends)/max(pg_settings_max_connections)",
@@ -3096,8 +3124,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 4,
-        "x": 20,
+        "w": 3,
+        "x": 21,
         "y": 67
       },
       "id": 15,
@@ -3116,7 +3144,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "expr": "sum(pg_stat_database_xact_commit{instance=\"$Instance\"})/(sum(pg_stat_database_xact_commit{instance=\"$Instance\"}) + sum(pg_stat_database_xact_rollback{instance=\"$Instance\"}))",
@@ -3194,9 +3222,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -3305,9 +3334,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -3417,9 +3447,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -3502,9 +3533,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "targets": [
         {
           "datasource": {
@@ -3591,9 +3623,10 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -3634,103 +3667,125 @@
       "valueName": "current"
     },
     {
-      "aliasColors": {},
-      "bars": true,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "decimals": 0,
-      "description": "View: pg_stat_activity",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
       "fieldConfig": {
         "defaults": {
-          "links": []
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 51,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 6,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 12,
         "y": 73
       },
-      "hiddenSeries": false,
-      "id": 121,
-      "interval": "$Interval",
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "hideEmpty": true,
-        "hideZero": true,
-        "max": true,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": false,
-      "linewidth": 1,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "PostgreSQL Documentation",
-          "url": "https://www.postgresql.org/docs/current/monitoring-stats.html"
-        }
-      ],
-      "nullPointMode": "null as zero",
+      "id": 142,
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "10.2.0",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (datname) (pg_stat_activity_count{instance=\"$Instance\"})",
-          "legendFormat": "{{datname}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Connections by database (stacked) (Postgres)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 0,
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pg_stat_user_tables_n_live_tup{datname=\"postgres\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Live",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
         },
         {
-          "decimals": 0,
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "pg_stat_user_tables_n_dead_tup",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Dead",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
         }
       ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Estimated number of rows (Postgres)",
+      "type": "timeseries"
     },
     {
       "aliasColors": {},
@@ -3784,7 +3839,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3832,105 +3887,18 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "description": "Source: pg_stat_database",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 82
+        "y": 81
       },
-      "hiddenSeries": false,
-      "id": 27,
-      "legend": {
-        "alignAsTable": true,
-        "avg": true,
-        "current": true,
-        "hideZero": false,
-        "max": true,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
+      "id": 141,
+      "libraryPanel": {
+        "name": "Database Size (Postgres)",
+        "uid": "eedb4531-abdb-4c30-92f6-6545c862a1f5"
       },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "10.2.0",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum((rate(pg_stat_database_tup_inserted{instance=\"$Instance\"}[$Interval])))",
-          "interval": "",
-          "legendFormat": "Inserts",
-          "refId": "A"
-        },
-        {
-          "expr": "sum((rate(pg_stat_database_tup_updated{instance=\"$Instance\"}[$Interval])))",
-          "interval": "",
-          "legendFormat": "Updates",
-          "refId": "B"
-        },
-        {
-          "expr": "sum((rate(pg_stat_database_tup_deleted{instance=\"$Instance\"}[$Interval])))",
-          "interval": "",
-          "legendFormat": "Deletes",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Tuples inserts/updates/deletes (Postgres)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "none",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Database Size (Postgres)"
     },
     {
       "aliasColors": {},
@@ -3977,7 +3945,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4032,11 +4000,12 @@
     },
     {
       "aliasColors": {},
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Source: pg_stat_database\n\n* tup_fetched: rows needed to satisfy queries\n* tup_returned: rows read/scanned",
+      "decimals": 0,
+      "description": "View: pg_stat_activity",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -4049,53 +4018,56 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 91
+        "y": 89
       },
       "hiddenSeries": false,
-      "id": 111,
+      "id": 121,
+      "interval": "$Interval",
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
-        "hideZero": false,
+        "hideEmpty": true,
+        "hideZero": true,
         "max": true,
         "min": false,
+        "rightSide": false,
         "show": true,
         "total": false,
         "values": true
       },
-      "lines": true,
+      "lines": false,
       "linewidth": 1,
-      "nullPointMode": "null",
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "PostgreSQL Documentation",
+          "url": "https://www.postgresql.org/docs/current/monitoring-stats.html"
+        }
+      ],
+      "nullPointMode": "null as zero",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": false,
+      "stack": true,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((rate(pg_stat_database_tup_fetched{instance=\"$Instance\"}[$Interval])))",
-          "interval": "",
-          "legendFormat": "Fetched",
+          "expr": "sum by (datname) (pg_stat_activity_count{instance=\"$Instance\"})",
+          "legendFormat": "{{datname}}",
           "refId": "A"
-        },
-        {
-          "expr": "sum((rate(pg_stat_database_tup_returned{instance=\"$Instance\"}[$Interval])))",
-          "interval": "",
-          "legendFormat": "Returned",
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Tuples fetched/returned (Postgres)",
+      "title": "Connections by database (stacked) (Postgres)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4109,16 +4081,16 @@
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
           "logBase": 1,
-          "min": "0",
           "show": true
         },
         {
+          "decimals": 0,
           "format": "short",
           "logBase": 1,
-          "min": "0",
-          "show": false
+          "show": true
         }
       ],
       "yaxis": {
@@ -4165,7 +4137,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4225,7 +4197,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Should be 0 \n\nSource: pg_stat_database\n\nWith log_lock_waits turned on, deadlocks will be logged to the PostgreSQL Logfiles.",
+      "description": "Source: pg_stat_database",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -4235,19 +4207,18 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 5,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 100
+        "y": 98
       },
       "hiddenSeries": false,
-      "id": 30,
+      "id": 27,
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
-        "hideEmpty": true,
-        "hideZero": true,
+        "hideZero": false,
         "max": true,
         "min": false,
         "show": true,
@@ -4256,18 +4227,12 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [
-        {
-          "title": "PostgreSQL Locking",
-          "url": "https://www.postgresql.org/docs/12/explicit-locking.html"
-        }
-      ],
       "nullPointMode": "null",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4277,15 +4242,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (datname) ((rate(pg_stat_database_deadlocks{instance=\"$Instance\"}[$Interval])))",
+          "expr": "sum((rate(pg_stat_database_tup_inserted{instance=\"$Instance\"}[$Interval])))",
           "interval": "",
-          "legendFormat": "{{datname}}",
+          "legendFormat": "Inserts",
           "refId": "A"
+        },
+        {
+          "expr": "sum((rate(pg_stat_database_tup_updated{instance=\"$Instance\"}[$Interval])))",
+          "interval": "",
+          "legendFormat": "Updates",
+          "refId": "B"
+        },
+        {
+          "expr": "sum((rate(pg_stat_database_tup_deleted{instance=\"$Instance\"}[$Interval])))",
+          "interval": "",
+          "legendFormat": "Deletes",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Deadlocks by database (Postgres)",
+      "title": "Tuples inserts/updates/deletes (Postgres)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4361,7 +4338,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4412,7 +4389,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Should be 0. If temporary files are created, it can indicate insufficient work_mem. With log_temp_files the creation of temporary files are logged to the PostgreSQL Logfiles.",
+      "description": "Source: pg_stat_database\n\n* tup_fetched: rows needed to satisfy queries\n* tup_returned: rows read/scanned",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -4422,19 +4399,18 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 5,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 105
+        "y": 107
       },
       "hiddenSeries": false,
-      "id": 31,
+      "id": 111,
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
-        "hideEmpty": true,
-        "hideZero": true,
+        "hideZero": false,
         "max": true,
         "min": false,
         "show": true,
@@ -4443,18 +4419,12 @@
       },
       "lines": true,
       "linewidth": 1,
-      "links": [
-        {
-          "title": "PostgreSQL Ressources",
-          "url": "https://www.postgresql.org/docs/current/runtime-config-resource.html"
-        }
-      ],
       "nullPointMode": "null",
       "options": {
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4464,15 +4434,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (datname) ((rate(pg_stat_database_temp_files{instance=\"$Instance\"}[$Interval])))",
+          "expr": "sum((rate(pg_stat_database_tup_fetched{instance=\"$Instance\"}[$Interval])))",
           "interval": "",
-          "legendFormat": "{{datname}}",
+          "legendFormat": "Fetched",
           "refId": "A"
+        },
+        {
+          "expr": "sum((rate(pg_stat_database_tup_returned{instance=\"$Instance\"}[$Interval])))",
+          "interval": "",
+          "legendFormat": "Returned",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Temporary files by database (Postgres)",
+      "title": "Tuples fetched/returned (Postgres)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -4486,7 +4462,7 @@
       },
       "yaxes": [
         {
-          "format": "none",
+          "format": "short",
           "logBase": 1,
           "min": "0",
           "show": true
@@ -4495,7 +4471,7 @@
           "format": "short",
           "logBase": 1,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -4544,7 +4520,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.2.0",
+      "pluginVersion": "10.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -4592,9 +4568,201 @@
       "yaxis": {
         "align": false
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Should be 0 \n\nSource: pg_stat_database\n\nWith log_lock_waits turned on, deadlocks will be logged to the PostgreSQL Logfiles.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "hiddenSeries": false,
+      "id": 30,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "title": "PostgreSQL Locking",
+          "url": "https://www.postgresql.org/docs/12/explicit-locking.html"
+        }
+      ],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (datname) ((rate(pg_stat_database_deadlocks{instance=\"$Instance\"}[$Interval])))",
+          "interval": "",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Deadlocks by database (Postgres)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Should be 0. If temporary files are created, it can indicate insufficient work_mem. With log_temp_files the creation of temporary files are logged to the PostgreSQL Logfiles.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 121
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [
+        {
+          "title": "PostgreSQL Ressources",
+          "url": "https://www.postgresql.org/docs/current/runtime-config-resource.html"
+        }
+      ],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.2.2",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (datname) ((rate(pg_stat_database_temp_files{instance=\"$Instance\"}[$Interval])))",
+          "interval": "",
+          "legendFormat": "{{datname}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Temporary files by database (Postgres)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
     }
   ],
-  "refresh": "",
+  "refresh": "5m",
   "revision": 1,
   "schemaVersion": 38,
   "tags": [],
@@ -4721,7 +4889,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/monitoring/configuration/dashboards/nwaku-monitoring.json
+++ b/monitoring/configuration/dashboards/nwaku-monitoring.json
@@ -2591,12 +2591,408 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "postgres",
+        "uid": "e5d2e0c2-371d-4178-ac71-edc122fb459c"
+      },
+      "description": "Number of messages in local database per shard.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "/waku/2/rs/1/0": {
+                  "index": 0,
+                  "text": "0"
+                },
+                "/waku/2/rs/1/1": {
+                  "index": 1,
+                  "text": "1"
+                },
+                "/waku/2/rs/1/2": {
+                  "index": 2,
+                  "text": "2"
+                },
+                "/waku/2/rs/1/3": {
+                  "index": 3,
+                  "text": "3"
+                },
+                "/waku/2/rs/1/4": {
+                  "index": 4,
+                  "text": "4"
+                },
+                "/waku/2/rs/1/5": {
+                  "index": 5,
+                  "text": "5"
+                },
+                "/waku/2/rs/1/6": {
+                  "index": 6,
+                  "text": "6"
+                },
+                "/waku/2/rs/1/7": {
+                  "index": 7,
+                  "text": "7"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Payload Size"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 9,
+        "x": 0,
+        "y": 66
+      },
+      "id": 143,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "e5d2e0c2-371d-4178-ac71-edc122fb459c"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "hide": false,
+          "rawQuery": true,
+          "rawSql": "SELECT pubsubtopic, COUNT(id), sum(pg_column_size(payload))\nFROM messages\nGROUP BY pubsubtopic",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [
+                  {
+                    "name": "pubsubtopic",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "name": "pubsubtopic",
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "messages"
+        }
+      ],
+      "title": "Stored Message by Shard",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Shard": "",
+              "count": "Number of Stored Messages",
+              "pubsubtopic": "Shard",
+              "sum": "Total Payload Size"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Shard"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "e5d2e0c2-371d-4178-ac71-edc122fb459c"
+      },
+      "description": "Messages in local database per app name, as extracted from the content topic.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "/waku/2/rs/1/0": {
+                  "index": 0,
+                  "text": "0"
+                },
+                "/waku/2/rs/1/1": {
+                  "index": 1,
+                  "text": "1"
+                },
+                "/waku/2/rs/1/2": {
+                  "index": 2,
+                  "text": "2"
+                },
+                "/waku/2/rs/1/3": {
+                  "index": 3,
+                  "text": "3"
+                },
+                "/waku/2/rs/1/4": {
+                  "index": 4,
+                  "text": "4"
+                },
+                "/waku/2/rs/1/5": {
+                  "index": 5,
+                  "text": "5"
+                },
+                "/waku/2/rs/1/6": {
+                  "index": 6,
+                  "text": "6"
+                },
+                "/waku/2/rs/1/7": {
+                  "index": 7,
+                  "text": "7"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Number of Messages (sum)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Payload Size (sum)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 9,
+        "x": 9,
+        "y": 66
+      },
+      "id": 144,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 1,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "e5d2e0c2-371d-4178-ac71-edc122fb459c"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "hide": false,
+          "rawQuery": true,
+          "rawSql": "SELECT REGEXP_REPLACE(contenttopic,'^\\/(.+)\\/(\\d+)\\/(.+)\\/(.+)$','\\1') as \"App name\", COUNT(id), pg_column_size(payload)\nFROM messages\nGROUP BY contenttopic, payload",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [
+                  {
+                    "name": "pubsubtopic",
+                    "type": "functionParameter"
+                  }
+                ],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "name": "pubsubtopic",
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          },
+          "table": "messages"
+        }
+      ],
+      "title": "Stored Message by Content Topic App Name",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "contenttopic": "App name",
+              "count": "Number of Messages",
+              "pg_column_size": "Total Payload Size"
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "App name": {
+                "aggregations": [
+                  "uniqueValues"
+                ],
+                "operation": "groupby"
+              },
+              "Number of Messages": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "Total Payload Size": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              },
+              "pg_column_size": {
+                "aggregations": [
+                  "sum"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Number of Messages (sum)"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 77
       },
       "id": 46,
       "panels": [],
@@ -2635,7 +3031,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 67
+        "y": 78
       },
       "id": 11,
       "links": [],
@@ -2747,7 +3143,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 67
+        "y": 78
       },
       "id": 84,
       "links": [],
@@ -2860,7 +3256,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 67
+        "y": 78
       },
       "id": 23,
       "links": [],
@@ -2935,7 +3331,7 @@
         "h": 6,
         "w": 3,
         "x": 12,
-        "y": 67
+        "y": 78
       },
       "id": 140,
       "libraryPanel": {
@@ -2986,7 +3382,7 @@
         "h": 6,
         "w": 3,
         "x": 15,
-        "y": 67
+        "y": 78
       },
       "id": 16,
       "links": [],
@@ -3056,7 +3452,7 @@
         "h": 6,
         "w": 3,
         "x": 18,
-        "y": 67
+        "y": 78
       },
       "id": 9,
       "links": [],
@@ -3126,7 +3522,7 @@
         "h": 6,
         "w": 3,
         "x": 21,
-        "y": 67
+        "y": 78
       },
       "id": 15,
       "links": [],
@@ -3193,7 +3589,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 70
+        "y": 81
       },
       "id": 37,
       "links": [],
@@ -3304,7 +3700,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 70
+        "y": 81
       },
       "id": 14,
       "interval": "",
@@ -3418,7 +3814,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 70
+        "y": 81
       },
       "id": 93,
       "links": [],
@@ -3518,7 +3914,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 73
+        "y": 84
       },
       "id": 125,
       "options": {
@@ -3594,7 +3990,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 73
+        "y": 84
       },
       "id": 102,
       "links": [],
@@ -3731,7 +4127,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 84
       },
       "id": 142,
       "options": {
@@ -3807,7 +4203,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 78
+        "y": 89
       },
       "hiddenSeries": false,
       "id": 24,
@@ -3891,7 +4287,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 81
+        "y": 92
       },
       "id": 141,
       "libraryPanel": {
@@ -3920,7 +4316,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 87
+        "y": 98
       },
       "hiddenSeries": false,
       "id": 122,
@@ -4018,7 +4414,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 89
+        "y": 100
       },
       "hiddenSeries": false,
       "id": 121,
@@ -4116,7 +4512,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 96
+        "y": 107
       },
       "hiddenSeries": false,
       "id": 26,
@@ -4210,7 +4606,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 98
+        "y": 109
       },
       "hiddenSeries": false,
       "id": 27,
@@ -4311,7 +4707,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 105
+        "y": 116
       },
       "hiddenSeries": false,
       "id": 123,
@@ -4402,7 +4798,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 107
+        "y": 118
       },
       "hiddenSeries": false,
       "id": 111,
@@ -4497,7 +4893,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 126
       },
       "hiddenSeries": false,
       "id": 120,
@@ -4588,7 +4984,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 116
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 30,
@@ -4684,7 +5080,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 121
+        "y": 132
       },
       "hiddenSeries": false,
       "id": 31,
@@ -4762,7 +5158,7 @@
       }
     }
   ],
-  "refresh": "5m",
+  "refresh": false,
   "revision": 1,
   "schemaVersion": 38,
   "tags": [],
@@ -4827,15 +5223,15 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": false,
-          "text": "auto",
-          "value": "$__auto_interval_Interval"
+          "selected": true,
+          "text": "10m",
+          "value": "10m"
         },
         "hide": 0,
         "name": "Interval",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "auto",
             "value": "$__auto_interval_Interval"
           },
@@ -4850,7 +5246,7 @@
             "value": "1m"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "10m",
             "value": "10m"
           },
@@ -4889,8 +5285,8 @@
     ]
   },
   "time": {
-    "from": "now-1h",
-    "to": "now"
+    "from": "2023-12-27T02:18:33.155Z",
+    "to": "2023-12-27T04:18:33.159Z"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/monitoring/configuration/dashboards/nwaku-monitoring.json
+++ b/monitoring/configuration/dashboards/nwaku-monitoring.json
@@ -5158,7 +5158,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": "auto",
   "revision": 1,
   "schemaVersion": 38,
   "tags": [],
@@ -5223,7 +5223,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "10m",
           "value": "10m"
         },


### PR DESCRIPTION
Adding some postgres related panels using Prometheus source.

![image](https://github.com/waku-org/nwaku-compose/assets/110212804/44c981bf-938a-44df-b660-3107f8d13435)

I will add panels with PostgreSQL source in follow-up PR.