### PR TITLE
fix:errors noticed when upgrading from older version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ x-pg-exporter-env: &pg_exp_env
 # Services definitions
 services:
   nwaku:
-    image: ${NWAKU_IMAGE:-wakuorg/nwaku:v0.22.0-rc.0}
+    image: ${NWAKU_IMAGE:-harbor.status.im/wakuorg/nwaku:v0.23.0}
     restart: on-failure
     ports:
       - 30304:30304/tcp
@@ -47,7 +47,7 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       NODEKEY: ${NODEKEY}
-      KEYSTORE_PASSWORD: "${KEYSTORE_PASSWORD}"
+      RLN_RELAY_CRED_PASSWORD: "${RLN_RELAY_CRED_PASSWORD}"
       ETH_CLIENT_ADDRESS: *eth_client_address
       EXTRA_ARGS: ${EXTRA_ARGS}
       <<:

--- a/run_node.sh
+++ b/run_node.sh
@@ -51,7 +51,7 @@ RLN_RELAY_CRED_PATH=--rln-relay-cred-path=${RLN_RELAY_CRED_PATH:-/keystore/keyst
 
 
 if [ -n "${RLN_RELAY_CRED_PASSWORD}" ]; then
-    RLN_RELAY_CRED_PASSWORD=--rln-relay-cred-password="'"${RLN_RELAY_CRED_PASSWORD}"'"
+    RLN_RELAY_CRED_PASSWORD=--rln-relay-cred-password="${RLN_RELAY_CRED_PASSWORD}"
 fi
 
 exec /usr/bin/wakunode\
@@ -84,6 +84,7 @@ exec /usr/bin/wakunode\
   --metrics-server-port=8003\
   --metrics-server-address=0.0.0.0\
   --rest=true\
+  --rest-admin=true\
   --rest-address=0.0.0.0\
   --rest-port=8645\
   --nat=extip:"${MY_EXT_IP}"\


### PR DESCRIPTION
After upgrade my existing nwaku node to latest master, node did not start and was restarting with below errros.

- Got following error eventhough my .env file is having the field RLN_RELAY_CRED_PASSWORD set.  Error goes away after i export KEYSTORE_PASSWORD .

`WARNING: The KEYSTORE_PASSWORD variable is not set. Defaulting to a blank string.`

- Even after trying to export KEYSTORE_PASSWORD var,  my node is still not coming up and keeps failing with below error. 

`ERR 2024-01-09 04:49:07.296+00:00 4/7 Mounting protocols failed              topics="wakunode main" tid=1 file=wakunode2.nim:89 error="failed to mount waku RLN relay protocol: failed to mount WakuRlnRelay: exception in new WakuRlnRelay: could not parse the keystore: Error while reading keyfile for credentials: keyfile error: mac verification failed"`

- Also updated to latest nwaku release version and added rest-admin to be enabled by default as it is useful

This PR fixes the above.

Thanks @gabrielmer for pointers to fix.
