### PR TITLE
docker-compose.yml: keystore.json file should be mounted like a file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - ./run_node.sh:/opt/run_node.sh:Z
       - ./certs:/etc/letsencrypt/:Z
       - ./rln_tree:/etc/rln_tree/:Z
-      - ./keystore/keystore.json:/keystore/keystore.json/:Z
+      - ./keystore/keystore.json:/keystore/keystore.json:Z
     entrypoint: sh
     command:
       - /opt/run_node.sh


### PR DESCRIPTION
This is to avoid the following error:
```
Error response from daemon: failed to create task for container: failed to create shim task: 
OCI runtime create failed: runc create failed: unable to start container process: error during 
container init: error mounting "/home/petty/nwaku-compose/keystore/keystore.json" to 
rootfs at "/keystore/keystore.json": 
mount /home/petty/nwaku-compose/keystore/keystore.json:/keystore/keystore.json
 (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you 
trying to mount a directory onto a file 
(or vice-versa)? Check if the specified host path exists and is the expected type
```