### PR TITLE
Update README.md $(date +%s%N) -> '$(date +%s%N)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ curl http://127.0.0.1:8645/debug/v1/info
 ```
 curl -X POST "http://127.0.0.1:8645/relay/v1/auto/messages" \
  -H "content-type: application/json" \
- -d '{"payload":"'$(echo -n "Hello Waku Network - from Anonymous User" | base64)'","contentTopic":"/my-app/2/chatroom-1/proto","timestamp":$(date +%s%N)}'
+ -d '{"payload":"'$(echo -n "Hello Waku Network - from Anonymous User" | base64)'","contentTopic":"/my-app/2/chatroom-1/proto","timestamp":`$(date +%s%N)`}'
 ```
 
 **Get messages sent to a `contentTopic`**. Note that any store node in the network is used to reply.


### PR DESCRIPTION
This PR aims to avoid the following error when using one command from the README.md:

`Invalid content body, could not decode. Unable to deserialize data%`