### PR TITLE
docker-compose.yml: pass user and database name when calling pg_isready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     ports: []
     #  - 127.0.0.1:5432:5432
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d db_prod"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
       interval: 30s
       timeout: 60s
       retries: 5


### PR DESCRIPTION
The postgres container, within the docker-compose file, starts an internal healthcheck. In this commit we are avoiding the following message to appear:
> FATAL:  role "root" does not exist