### PR TITLE
mounting keystore directory instead of keystore.json

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - ./run_node.sh:/opt/run_node.sh:Z
       - ${CERTS_DIR:-./certs}:/etc/letsencrypt/:Z
       - ./rln_tree:/etc/rln_tree/:Z
-      - ./keystore/keystore.json:/keystore/keystore.json:Z
+      - ./keystore:/keystore:Z
     entrypoint: sh
     command:
       - /opt/run_node.sh


### PR DESCRIPTION
# Description
Mounting the whole `/keystore` directory in `docker-compose.yml` instead of `/keystore/keystore.json`

In case the keystore hasn't been generated yet, the `/keystore` directory will be automatically created by docker instead of a `/keystore/keystore.json` directory.

In general, it's better for the volumes mounted to be intended directories instead of files. 

## Issue: 
Advances https://github.com/waku-org/nwaku-compose/issues/32