### PR TITLE
Update .env.example: use ETH_TESTNET_KEY=<YOUR_PRIVATE_KEY_HERE>

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/<key>  #RPC URL for accessing testnet via websockets.
-ETH_TESTNET_KEY=012345privatekey        # Privatekey of testnet where you have sepolia ETH that would be staked into RLN contract
+ETH_TESTNET_KEY=<YOUR_PRIVATE_KEY_HERE>        # Privatekey of testnet where you have sepolia ETH that would be staked into RLN contract
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password" #Password you would like to use to protect your RLN membership
 
 # Advanced

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/<key>  #RPC URL for accessing testnet via websockets.
-ETH_TESTNET_KEY=<YOUR_PRIVATE_KEY_HERE>        # Privatekey of testnet where you have sepolia ETH that would be staked into RLN contract
+ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>        # Privatekey of testnet where you have sepolia ETH that would be staked into RLN contract
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password" #Password you would like to use to protect your RLN membership
 
 # Advanced


### PR DESCRIPTION
Remove the previous hint because a user got confused as he/she thought the `012345` should be kept somehow