### PR TITLE
chore(rln-relay): update docs and .env.example to include http instead of ws rpc url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-ETH_CLIENT_ADDRESS=wss://sepolia.infura.io/ws/v3/<key>  #RPC URL for accessing testnet via websockets.
+ETH_CLIENT_ADDRESS=https://sepolia.infura.io/v3/<key>  # RPC URL for accessing testnet via HTTP.
 ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>        # Privatekey of testnet where you have sepolia ETH that would be staked into RLN contract
-RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password" #Password you would like to use to protect your RLN membership
+RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"  # Password you would like to use to protect your RLN membership
 
 # Advanced
 NWAKU_IMAGE=

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -10,7 +10,7 @@ There are multiple environment variables you can configure to modify behaviour o
 * `DOMAIN` - domain name pointing to the IP address of your node, when configured the run script will request SSL certs from Let's Encrypt and run Waku node with WebSockets Secure (WSS) options enabled (e.g. `DOMAIN=waku.example.com`)
 * `NODEKEY` - this env variable allows you to provide a node key as described in [operators documentation](https://github.com/waku-org/nwaku/blob/master/docs/operators/how-to/configure-key.md) (e.g. `NODEKEY=9f439983aa4851346cfe6e17585e426f482871a43626812e23490895cd602c11`)
 * `RLN_RELAY_CONTRACT_ADDRESS` - address of the RLN Relay Contract. It defaults to a Sepolia testnet address
-* `ETH_CLIENT_ADDRESS` (**mandatory**) - URL to a WebSockets Ethereum node URL on the same network as the contract address. If you're not running your own node, you can get the URL at Infura with the following [instructions](https://docs.infura.io/networks/ethereum/how-to/choose-a-network)
+* `ETH_CLIENT_ADDRESS` (**mandatory**) - URL to an HTTP Ethereum node URL on the same network as the contract address. If you're not running your own node, you can get the URL at Infura with the following [instructions](https://docs.infura.io/networks/ethereum/how-to/choose-a-network)
 * `RLN_RELAY_CRED_PATH` - path for peristing rln-relay credential
 * `RLN_RELAY_CRED_PASSWORD` - password for encrypting RLN credentials
 * `EXTRA_ARGS` - this variable allows you to specify additional or overriding CLI option for the Waku node which will be appended to the `wakunode2` command. (e.g. `EXTRA_ARGS="--store=false --max-connections=3000`)


### PR DESCRIPTION
Updates the documentation, companion PR: https://github.com/waku-org/nwaku/pull/2442
