### PR TITLE
chore: .env.example: give env vars examples for better understanding the expected format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
-ETH_CLIENT_ADDRESS=https://sepolia.infura.io/v3/<key>  # RPC URL for accessing testnet via HTTP.
-ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>        # Privatekey of testnet where you have sepolia ETH that would be staked into RLN contract
-RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"  # Password you would like to use to protect your RLN membership
+# RPC URL for accessing testnet via HTTP.
+# e.g. https://sepolia.infura.io/v3/123aa110320f4aec179150fba1e1b1b1
+ETH_CLIENT_ADDRESS=https://sepolia.infura.io/v3/<key>
 
-# Advanced
+# Private key of testnet where you have sepolia ETH that would be staked into RLN contract.
+# e.g. 0116196e9a8abed42dd1a22eb63fa2a5a17b0c27d716b87ded2c54f1bf192a0b
+ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
+
+# Password you would like to use to protect your RLN membership.
+RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"
+
+# Advanced. Can be left empty in normal use cases.
 NWAKU_IMAGE=
 NODEKEY=
 DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 ETH_CLIENT_ADDRESS=https://sepolia.infura.io/v3/<key>
 
 # Private key of testnet where you have sepolia ETH that would be staked into RLN contract.
-# e.g. 0116196e9a8abed42dd1a22eb63fa2a5a17b0c27d716b87ded2c54f1bf192a0b
+# Note: make sure you don't use the '0x' prefix.
+#       e.g. 0116196e9a8abed42dd1a22eb63fa2a5a17b0c27d716b87ded2c54f1bf192a0b
 ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
 
 # Password you would like to use to protect your RLN membership.


### PR DESCRIPTION
While interacting with a user, I noticed that he set the `ETH_TESTNET_KEY` with a value starting by `0x`. This is expected to be working. Nevertheless, we managed to make it work when he registered using a key without the `0x` prefix.

I'm also giving an example for `ETH_CLIENT_ADDRESS` and therefore keep similar structure in the whole `.env.example` file.