### PR TITLE
chore: not passing timestamp in post example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ curl http://127.0.0.1:8645/debug/v1/info
 ```
 curl -X POST "http://127.0.0.1:8645/relay/v1/auto/messages" \
  -H "content-type: application/json" \
- -d '{"payload":"'$(echo -n "Hello Waku Network - from Anonymous User" | base64)'","contentTopic":"/my-app/2/chatroom-1/proto","timestamp":'$(date +%s%N)'}'
+ -d '{"payload":"'$(echo -n "Hello Waku Network - from Anonymous User" | base64)'","contentTopic":"/my-app/2/chatroom-1/proto"}'
 ```
 
 **Get messages sent to a `contentTopic`**. Note that any store node in the network is used to reply.


### PR DESCRIPTION
In the README's example, better to not manually pass the timestamp.

It's better practice to let the node set the timestamp, and at the same time, the substitution `'$(date +%s%N)'` keeps creating issues in some machines.