### PR TITLE
chore: Upgrade nwaku image to v0.26.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ x-pg-exporter-env: &pg_exp_env
 # Services definitions
 services:
   nwaku:
-    image: ${NWAKU_IMAGE:-harbor.status.im/wakuorg/nwaku:v0.25.0}
+    image: ${NWAKU_IMAGE:-harbor.status.im/wakuorg/nwaku:v0.26.0}
     restart: on-failure
     ports:
       - 30304:30304/tcp

--- a/run_node.sh
+++ b/run_node.sh
@@ -84,6 +84,7 @@ exec /usr/bin/wakunode\
   --rest-admin=true\
   --rest-address=0.0.0.0\
   --rest-port=8645\
+  --rest-allow-origin="waku-org.github.io"\
   --nat=extip:"${MY_EXT_IP}"\
   --store=true\
   --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\


### PR DESCRIPTION
... and utilize Waku Rest reference page access to REST API.

v0.26.0 of nwaku is out!