### PR TITLE
feat: add caddy service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 keystore
 postgresql
 rln_tree
-.env
+caddy

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -51,3 +51,10 @@ proofs, hashing, Merkle tree, Blockchain, etc.
 Deeper technical details can be found in:
 * [RLN-V1 spec](https://rfc.vac.dev/spec/32/)
 * [RLN-V2 spec](https://rfc.vac.dev/spec/58/)
+
+## Caddy Configuration
+
+Optionally, you can run it with caddy which gives a free SSL certificate for REST API,
+- set the A record in DNS settings to your server IP address
+- change `your-domain.com` in `Caddyfile`
+- run `docker-compose --profile prod up -d`

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,14 @@
+your-domain.com {
+    @cors_preflight {
+            method OPTIONS
+    }
+    respond @cors_preflight 204
+
+    header {
+            Access-Control-Allow-Origin *
+            Access-Control-Allow-Methods GET,POST,OPTIONS,HEAD,PATCH,PUT,DELETE
+            Access-Control-Allow-Headers User-Agent,Content-Type,X-Api-Key
+            Access-Control-Max-Age 86400
+    }
+    reverse_proxy :8645
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -10,5 +10,5 @@ your-domain.com {
             Access-Control-Allow-Headers User-Agent,Content-Type,X-Api-Key
             Access-Control-Max-Age 86400
     }
-    reverse_proxy :8645
+    reverse_proxy nwaku:8645
 }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ docker-compose up -d
 ```
 ⚠️ The node might take ~5' the very first time it runs because it needs to build locally the RLN community membership tree.
 
+Optionally, you can run it with caddy which gives a free SSL certificate for REST API,
+- set the A record in DNS settings to your server IP address
+- change `your-domain.com` in `Caddyfile`
+- run `docker-compose --profile prod up -d`
+
 **🏄🏼‍♂️ 3. Interact with your nwaku node**
 * See [http://localhost:3000/d/yns_4vFVk/nwaku-monitoring](http://localhost:3000/d/yns_4vFVk/nwaku-monitoring) for node metrics.
 * See [localhost:4000](http://localhost:4000). Under development 🚧

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ docker-compose up -d
 ```
 ⚠️ The node might take ~5' the very first time it runs because it needs to build locally the RLN community membership tree.
 
-Optionally, you can run it with caddy which gives a free SSL certificate for REST API,
-- set the A record in DNS settings to your server IP address
-- change `your-domain.com` in `Caddyfile`
-- run `docker-compose --profile prod up -d`
-
 **🏄🏼‍♂️ 3. Interact with your nwaku node**
 * See [http://localhost:3000/d/yns_4vFVk/nwaku-monitoring](http://localhost:3000/d/yns_4vFVk/nwaku-monitoring) for node metrics.
 * See [localhost:4000](http://localhost:4000). Under development 🚧

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - 30304:30304/udp
       - 9005:9005/udp
       - 127.0.0.1:8003:8003
-      - 80:80 #Let's Encrypt
+      - 88:80 #Let's Encrypt
       - 8000:8000/tcp #WSS
       - 127.0.0.1:8645:8645
     <<:
@@ -141,3 +141,19 @@ services:
       - --config.file=/etc/pgexporter/postgres-exporter.yml
     depends_on:
       - postgres
+  
+  caddy:
+    image: caddy:2.7.6
+    profiles: [prod]
+    restart: on-failure:5
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./caddy/data:/data
+      - ./caddy/config:/config
+

--- a/run_node.sh
+++ b/run_node.sh
@@ -78,7 +78,6 @@ exec /usr/bin/wakunode\
   --rest-admin=true\
   --rest-address=0.0.0.0\
   --rest-port=8645\
-  --rest-allow-origin="waku-org.github.io"\
   --nat=extip:"${MY_EXT_IP}"\
   --store=true\
   --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\


### PR DESCRIPTION
It enables,
- fix CORS options preflight request for nwaku
- free certificates for https


I don't have permission to push to this repo, could someone change this repo settings to allow `waku` team push changes?