### PR TITLE
chore: pgadmin addon to administer docker store DB

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -51,3 +51,12 @@ proofs, hashing, Merkle tree, Blockchain, etc.
 Deeper technical details can be found in:
 * [RLN-V1 spec](https://rfc.vac.dev/spec/32/)
 * [RLN-V2 spec](https://rfc.vac.dev/spec/58/)
+
+## DB Administration
+
+In case compositon is started with command
+```console
+docker compose --profile dbadmin up -d
+```
+an additional service - pgadmin - is started and can be accessed from browser on http://localhost:15432
+That will give insights on the Node's message store database.

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -60,3 +60,10 @@ docker compose --profile dbadmin up -d
 ```
 an additional service - pgadmin - is started and can be accessed from browser on http://localhost:15432
 That will give insights on the Node's message store database.
+
+### Shutting down the container with pgadmin service
+
+If started with 'dbadmin' profile it must be used when stopping it:
+```console
+docker compose --profile dbadmin down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,3 +141,46 @@ services:
       - --config.file=/etc/pgexporter/postgres-exporter.yml
     depends_on:
       - postgres
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=waku@waku.com
+      - PGADMIN_DEFAULT_PASSWORD=wakuwaku
+      - PGADMIN_CONFIG_SERVER_MODE=False
+      - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+      - PGADMIN_LISTEN_PORT=80
+    ports:
+      - 15432:80
+    user: root
+    entrypoint: /bin/sh -c "chmod 600 /pgpass; /entrypoint.sh;"
+    volumes:
+      - pgadmin:/var/lib/pgadmin
+    configs:
+      - source: servers.json
+        target: /pgadmin4/servers.json
+      - source: pgpass
+        target: /pgpass
+    depends_on:
+      - postgres
+    profiles:
+      - dbadmin
+
+volumes:
+  pgadmin:
+
+configs:
+  pgpass:
+    content: postgres:5432:*:${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-test123}
+  servers.json:
+    content: |
+      {"Servers": {"1": {
+        "Group": "Servers",
+        "Name": "WakuStoreDB",
+        "Host": "postgres",
+        "Port": 5432,
+        "MaintenanceDB": "postgres",
+        "Username": "postgres",
+        "PassFile": "/pgpass",
+        "SSLMode": "disable"
+      }}}


### PR DESCRIPTION
Added a new service to regular compose:

pgadmin: will help administer composed postgres DB from a regular browser.

if starting up as: 
```docker compose --profile dbadmin up -d```

_Note: pgadmin image starts only with dbadmin profile, otherwise will not._

User can navigate to http://localhost:15432 and can access admin interface to the composed DB. Credentials are embedded into the docker-compose descriptor.
