### PR TITLE
avoid exposing port 9090 to prevent clashes with other local services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,8 @@ services:
       - ./monitoring/prometheus-config.yml:/etc/prometheus/prometheus.yml:Z
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-    ports:
-      - 127.0.0.1:9090:9090
+    # ports:
+    #   - 127.0.0.1:9090:9090
     restart: on-failure:5
     depends_on:
       - postgres-exporter


### PR DESCRIPTION
Simple PR to avoid clashes with local running services.
We encounter some node operators facing this issue.