### PR TITLE
fix: don't exit if certificate is not generated

### DIFF
--- a/run_node.sh
+++ b/run_node.sh
@@ -62,7 +62,7 @@ if [ -n "${DOMAIN}" ]; then
     fi
 
     if ! [ -e "${LETSENCRYPT_PATH}/privkey.pem" ]; then
-        echo "The certificate does not exist. Proceeding without supporting the domain"
+        echo "The certificate does not exist. Proceeding without supporting websocket"
     else
         WS_SUPPORT="--websocket-support=true"
         WSS_SUPPORT="--websocket-secure-support=true"

--- a/run_node.sh
+++ b/run_node.sh
@@ -62,18 +62,16 @@ if [ -n "${DOMAIN}" ]; then
     fi
 
     if ! [ -e "${LETSENCRYPT_PATH}/privkey.pem" ]; then
-        echo "The certificate does not exist"
-        sleep 60
-        exit 1
+        echo "The certificate does not exist. Proceeding without supporting the domain"
+    else
+        WS_SUPPORT="--websocket-support=true"
+        WSS_SUPPORT="--websocket-secure-support=true"
+        WSS_KEY="--websocket-secure-key-path=${LETSENCRYPT_PATH}/privkey.pem"
+        WSS_CERT="--websocket-secure-cert-path=${LETSENCRYPT_PATH}/cert.pem"
+        DNS4_DOMAIN="--dns4-domain-name=${DOMAIN}"
+
+        DNS_WSS_CMD="${WS_SUPPORT} ${WSS_SUPPORT} ${WSS_CERT} ${WSS_KEY} ${DNS4_DOMAIN}" 
     fi
-
-    WS_SUPPORT="--websocket-support=true"
-    WSS_SUPPORT="--websocket-secure-support=true"
-    WSS_KEY="--websocket-secure-key-path=${LETSENCRYPT_PATH}/privkey.pem"
-    WSS_CERT="--websocket-secure-cert-path=${LETSENCRYPT_PATH}/cert.pem"
-    DNS4_DOMAIN="--dns4-domain-name=${DOMAIN}"
-
-    DNS_WSS_CMD="${WS_SUPPORT} ${WSS_SUPPORT} ${WSS_CERT} ${WSS_KEY} ${DNS4_DOMAIN}"
 fi
 
 if [ -n "${NODEKEY}" ]; then


### PR DESCRIPTION
With the new feature of automatically fetching a domain, a user encountered the following issue:

![image](https://github.com/user-attachments/assets/a3e42451-2d35-43cf-95f1-11141f7ce625)

To prevent it, made a small fix in `run_node.sh` not exiting if the certificate couldn't be generated.
I was able to reproduce it locally with the new fix without halting execution:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/640abdac-6f16-46f9-8821-22e49f7c026f">
