### PR TITLE
docker-compose increase pg shared memory to 1 gb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
     # and the store-message-db-url is set to use Postgres
     image: postgres:15.4-alpine3.18
     restart: on-failure:5
+    shm_size: '1g'  # Set shared memory size to 1 GB
     environment:
       <<: *pg_env
     volumes:


### PR DESCRIPTION
This is aimed to increase the shared memory allowed to _Postgres_.
Notice that Docker by default limits the shared memory to 64MB which might not be enough for _Postgres_.

With this, we want to prevent issues like:
```nim
postgres-1  | 2024-08-21 13:44:21.948 UTC [28] STATEMENT:  SELECT
postgres-1  |       COUNT(ID)
postgres-1  |     FROM messages
postgres-1  |
postgres-1  | 2024-08-21 13:44:36.540 UTC [28] ERROR:  out of shared memory
postgres-1  | 2024-08-21 13:44:36.540 UTC [28] HINT:  You might need to increase max_locks_per_transaction.
postgres-1  | 2024-08-21 13:44:36.540 UTC [28] STATEMENT:  SELECT
postgres-1  |       COUNT(ID)
postgres-1  |     FROM messages
postgres-1  |
postgres-1  | 2024-08-21 13:44:36.796 UTC [28] ERROR:  out of shared memory
postgres-1  | 2024-08-21 13:44:36.796 UTC [28] HINT:  You might need to increase max_locks_per_transaction.
postgres-1  | 2024-08-21 13:44:36.796 UTC [28] STATEMENT:  select pubsubtopic, count(*) AS messages FROM (SELECT id, array_agg(pubsubtopic ORDER BY pubsubtopic) AS pubsubtopic FROM messages GROUP BY id) sub GROUP BY pubsubtopic ORDER BY pubsubtopic;
postgres-1  |
```