### PR TITLE
fix: use v0.32.0 for credentials registration

### DIFF
--- a/register_rln.sh
+++ b/register_rln.sh
@@ -20,7 +20,7 @@ if test -n "${ETH_CLIENT_ADDRESS}"; then
   exit 1
 fi
 
-docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.31.0 generateRlnKeystore \
+docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.32.0 generateRlnKeystore \
 --rln-relay-eth-client-address=${RLN_RELAY_ETH_CLIENT_ADDRESS} \
 --rln-relay-eth-private-key=${ETH_TESTNET_KEY} \
 --rln-relay-eth-contract-address=0xCB33Aa5B38d79E3D9Fa8B10afF38AA201399a7e3 \


### PR DESCRIPTION
`docker-compose.yml` uses nwaku v0.32.0 while keystore registration uses v0.31.0