### PR TITLE
fix: automatic log rotation with size limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     logging:
       driver: json-file
       options:
-        max-size: "1m"
+        max-size: "100m"
         max-file: "10"
         compress: "true"
         tag: "nwaku-{{.ID}}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,4 @@
 version: "3.7"
-x-logging: &logging
-  logging:
-    driver: json-file
-    options:
-      max-size: 100m
-      max-file: 10
-      compress: "true"
-
 # Environment variable definitions
 x-rln-relay-eth-client-address: &rln_relay_eth_client_address ${RLN_RELAY_ETH_CLIENT_ADDRESS:-} # Add your RLN_RELAY_ETH_CLIENT_ADDRESS after the "-"
 
@@ -43,8 +35,13 @@ services:
       - 80:80 #Let's Encrypt
       - 8000:8000/tcp #WSS
       - 127.0.0.1:8645:8645
-    <<:
-      - *logging
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "10"
+        compress: "true"
+        tag: "nwaku-{{.ID}}"
     environment:
       DOMAIN: ${DOMAIN}
       NODEKEY: ${NODEKEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ x-logging: &logging
   logging:
     driver: json-file
     options:
-      max-size: 1000m
+      max-size: 100m
+      max-file: 10
+      compress: "true"
 
 # Environment variable definitions
 x-rln-relay-eth-client-address: &rln_relay_eth_client_address ${RLN_RELAY_ETH_CLIENT_ADDRESS:-} # Add your RLN_RELAY_ETH_CLIENT_ADDRESS after the "-"


### PR DESCRIPTION
Add size-based log rotation to effectively manage disk space. As discussed, time-based log rotation is not necessary, as this configuration should adequately address our disk space concerns. 

close #143 