### PR TITLE
chore: add RLN_ENABLED and CLUSTER_ID env vars to allow run node without RLN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,16 @@ ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
 # Password you would like to use to protect your RLN membership.
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"
 
+# Optional parameter to disable RLN (1: enabled; 0 or empty: disabled)
+RLN_ENABLED=
+
+# Overrides the default cluster-id (1)
+CLUSTER_ID=
+
 # Advanced. Can be left empty in normal use cases.
 NWAKU_IMAGE=
 NODEKEY=
 DOMAIN=
 EXTRA_ARGS=
 STORAGE_SIZE=
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
       NODEKEY: ${NODEKEY}
+      CLUSTER_ID: ${CLUSTER_ID}
+      RLN_ENABLED: ${RLN_ENABLED}
       RLN_RELAY_CRED_PASSWORD: "${RLN_RELAY_CRED_PASSWORD}"
       RLN_RELAY_ETH_CLIENT_ADDRESS: *rln_relay_eth_client_address
       EXTRA_ARGS: ${EXTRA_ARGS}


### PR DESCRIPTION
This is inspired by @igor-sirotin's comment:
https://github.com/waku-org/nwaku/issues/3313#issuecomment-2708997549

The main purpose is to allow node operators start running Waku nodes without RLN (Rate-Limit Nullifier).

Notice though that we strongly encourage the usage of RLN.