### PR TITLE
chore: Update sepolia rln contract address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 x-rln-relay-eth-client-address: &rln_relay_eth_client_address ${RLN_RELAY_ETH_CLIENT_ADDRESS:-} # Add your RLN_RELAY_ETH_CLIENT_ADDRESS after the "-"
 
 x-rln-environment: &rln_env
-  RLN_RELAY_CONTRACT_ADDRESS: ${RLN_RELAY_CONTRACT_ADDRESS:-0xCB33Aa5B38d79E3D9Fa8B10afF38AA201399a7e3}
+  RLN_RELAY_CONTRACT_ADDRESS: ${RLN_RELAY_CONTRACT_ADDRESS:-0xfe7a9eabce779a090fd702346fd0bfac02ce6ac8}
   RLN_RELAY_CRED_PATH: ${RLN_RELAY_CRED_PATH:-} # Optional: Add your RLN_RELAY_CRED_PATH after the "-"
   RLN_RELAY_CRED_PASSWORD: ${RLN_RELAY_CRED_PASSWORD:-} # Optional: Add your RLN_RELAY_CRED_PASSWORD after the "-"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ x-pg-exporter-env: &pg_exp_env
 # Services definitions
 services:
   nwaku:
-    image: ${NWAKU_IMAGE:-wakuorg/nwaku:v0.35.0}
+    image: ${NWAKU_IMAGE:-wakuorg/nwaku:v0.35.1}
     restart: on-failure
     ports:
       - 30304:30304/tcp

--- a/register_rln.sh
+++ b/register_rln.sh
@@ -23,7 +23,7 @@ fi
 docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.35.0 generateRlnKeystore \
 --rln-relay-eth-client-address=${RLN_RELAY_ETH_CLIENT_ADDRESS} \
 --rln-relay-eth-private-key=${ETH_TESTNET_KEY} \
---rln-relay-eth-contract-address=0xCB33Aa5B38d79E3D9Fa8B10afF38AA201399a7e3 \
+--rln-relay-eth-contract-address=0xfe7a9eabce779a090fd702346fd0bfac02ce6ac8 \
 --rln-relay-cred-path=/keystore/keystore.json \
 --rln-relay-cred-password="${RLN_RELAY_CRED_PASSWORD}" \
 --rln-relay-user-message-limit=100 \

--- a/register_rln.sh
+++ b/register_rln.sh
@@ -20,7 +20,7 @@ if test -n "${ETH_CLIENT_ADDRESS}"; then
   exit 1
 fi
 
-docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.35.0 generateRlnKeystore \
+docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.35.1 generateRlnKeystore \
 --rln-relay-eth-client-address=${RLN_RELAY_ETH_CLIENT_ADDRESS} \
 --rln-relay-eth-private-key=${ETH_TESTNET_KEY} \
 --rln-relay-eth-contract-address=0xfe7a9eabce779a090fd702346fd0bfac02ce6ac8 \


### PR DESCRIPTION
This PR is to update the two uses of the RLN contract address to use the address of the newly deployed contract (which is still the same version and functionality as the current contract) as well as update the nwaku docker image version for the one with the fix that also uses the new contract address.

This is to mitigate the spamming issues at the current contract address.
TWN will shortly move to a new contract with membership fees.
