### PR TITLE
fix: New flow 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https:/
 
 ### 🚀 Starting your node — pick one of three paths
 
-| # | Path | Quick-start command | What happens | 
+| # | Option | Quick-start command | What happens | 
 |---|------|--------------------|--------------|
-| **1** | **setup_wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
+| **1** | **setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
 | **2** | **script** | Power user / CI | setup a .env file manually, run ./register_rln.sh, and then start the node.|
 
 <details>

--- a/README.md
+++ b/README.md
@@ -18,23 +18,11 @@ Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https:/
 
 | # | Path | Quick-start command | What happens | 
 |---|------|--------------------|--------------|
-| **1** | **rln.waku.org** | Guided web setup | Register RLN in the browser, download `keystore.json`, then return here to proceed |
-| **2** | **setup_wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
-| **3** | **Manual script** | Power users / CI | Mint & approve tokens yourself, then run the script for maximum control |
+| **1** | **setup_wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
+| **2** | **script** | Power user / CI | setup a .env file manually, run ./register_rln.sh, and then start the node.|
 
 <details>
-<summary>🌐 option 1 :- RLN.WAKU.ORG [ recommended ]</summary>
-
-To register for RLN membership and generate your keystore:
-
-1. Visit [https://rln.waku.org](https://rln.waku.org).
-2. Follow the instructions to register your membership and generate a `keystore.json` file.
-3. Download the generated `keystore.json` and place it in the `keystore/` directory of your `nwaku-compose` setup (i.e., at `keystore/keystore.json`).
-
-</details>
-
-<details>
-<summary>⚙️ option 2 :- SETUP-WIZARD [ experimental ]</summary>
+<summary>⚙️ option 1 :- SETUP-WIZARD [ experimental ]</summary>
 
 Run the wizard script.
 Once the script is done, the node will be started for you, so there is nothing else to do.
@@ -48,31 +36,14 @@ The script is experimental, feedback and pull requests are welcome.
 </details>
 
 <details>
-<summary>🧪 option 3 :- MANUAL SCRIPT [ advanced ] </summary>
-
-You can also register your membership using the provided script, which will store it in `keystore/keystore.json`.
-
-Before registering you need to mint and approve the tokens to pay for the registration.
-The simplest way is using Foundry's [cast](https://getfoundry.sh/) tool, which you can install with:
+<summary>🧪 option 2 :- SCRIPT [ manual ] [ recommended ] </summary>
 
 ```
-curl -L https://foundry.paradigm.xyz | bash
-foundryup
+cp .env.example .env  
 ```
-
-Mint the token used to pay for RLN Membership registration from your Linea Sepolia account (This is a generic ERC20 token used for testnet only):
-The amount of "5000000000000000000" is how much is needed to register with a `rln-relay-user-message-limit` of 100
-```
-cast send $TOKEN_CONTRACT_ADDRESS "mint(address,uint256)" $ETH_TESTNET_ACCOUNT 5000000000000000000 --private-key $ETH_TESTNET_KEY --rpc-url $RLN_RELAY_ETH_CLIENT_ADDRESS
-```
-
-Approve the RLN contract to spend tokens on behalf of your account:
-```
-cast send $TOKEN_CONTRACT_ADDRESS "approve(address,uint256)" $RLN_CONTRACT_ADDRESS 5000000000000000000 --private-key $ETH_TESTNET_KEY --rpc-url $RLN_RELAY_ETH_CLIENT_ADDRESS
-```
+Edit the .env file and fill in all required parameters 
 
 This command will register your membership and store it in `keystore/keystore.json`:
-
 ```
 ./register_rln.sh
 ```

--- a/README.md
+++ b/README.md
@@ -18,25 +18,11 @@ Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https:/
 
 | # | Option | Quick-start command | What happens | 
 |---|------|--------------------|--------------|
-| **1** | **setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
-| **2** | **script** | Power user / CI | setup a .env file manually, run ./register_rln.sh, and then start the node.|
+| **1** | **script** | Power user / CI | setup a .env file manually, run ./register_rln.sh, and then start the node.|
+| **2** | **setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
 
 <details>
-<summary>⚙️ option 1 :- SETUP-WIZARD [ experimental ]</summary>
-
-Run the wizard script.
-Once the script is done, the node will be started for you, so there is nothing else to do.
-
-The script is experimental, feedback and pull requests are welcome.
-
-```
-./setup_wizard.sh
-```
-
-</details>
-
-<details>
-<summary>🧪 option 2 :- SCRIPT [ manual ] [ recommended ] </summary>
+<summary>🧪 option 1 :- SCRIPT [ manual ] [ recommended ] </summary>
 
 ```
 cp .env.example .env  
@@ -118,6 +104,19 @@ For advanced documentation, refer to [ADVANCED.md](https://github.com/waku-org/n
 
 </details>
 
+<details>
+<summary>⚙️ option 1 :- SETUP-WIZARD [ experimental ]</summary>
+
+Run the wizard script.
+Once the script is done, the node will be started for you, so there is nothing else to do.
+
+The script is experimental, feedback and pull requests are welcome.
+
+```
+./setup_wizard.sh
+```
+
+</details>
 
 ### 📌 Note
 RLN membership is your access key to The Waku Network. It is registered on-chain, enabling your nwaku node to send messages in a decentralized and privacy-preserving way while adhering to rate limits. Messages exceeding the rate limit will not be relayed by other peers.

--- a/register_rln.sh
+++ b/register_rln.sh
@@ -20,6 +20,39 @@ if test -n "${ETH_CLIENT_ADDRESS}"; then
   exit 1
 fi
 
+# Ensure Foundry (cast & foundryup) is available for token mint/approve calls
+if ! command -v cast >/dev/null 2>&1; then
+  echo "Foundry toolkit (cast) not found. Installing Foundry..."
+  curl -L https://foundry.paradigm.xyz | bash
+  # Make the freshly installed binaries available in the current session
+  export PATH="$HOME/.foundry/bin:$PATH"
+  foundryup
+fi
+
+RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
+TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
+TTT_AMOUNT_WEI=5000000000000000000
+
+# Mint 
+if ! cast send "$TOKEN_CONTRACT_ADDRESS" "mint(address,uint256)" \
+        "$ETH_TESTNET_ACCOUNT" "$TTT_AMOUNT_WEI" \
+        --private-key "$ETH_TESTNET_KEY" \
+        --rpc-url   "$RLN_RELAY_ETH_CLIENT_ADDRESS"
+then
+  echo " Mint transaction failed."
+  exit 1
+fi
+
+# Approve 
+if ! cast send "$TOKEN_CONTRACT_ADDRESS" "approve(address,uint256)" \
+        "$RLN_CONTRACT_ADDRESS" "$TTT_AMOUNT_WEI" \
+        --private-key "$ETH_TESTNET_KEY" \
+        --rpc-url   "$RLN_RELAY_ETH_CLIENT_ADDRESS"
+then
+  echo "Approve transaction failed."
+  exit 1
+fi
+
 docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.36.0 generateRlnKeystore \
 --rln-relay-eth-client-address=${RLN_RELAY_ETH_CLIENT_ADDRESS} \
 --rln-relay-eth-private-key=${ETH_TESTNET_KEY} \


### PR DESCRIPTION
As discussed, rln.waku.org isn’t in good shape to be included in the README at the moment. So I’ve temporarily removed that flow from the README.

I’ve also integrated the minting and approval commands directly into register_rln.sh.

@stubbsta — if you’d prefer to give users more control over these commands or advocate for a different approach, I’m happy to revert this change.