### PR TITLE
Update default config for relay without publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,24 +2,9 @@
 # e.g. https://linea-sepolia.infura.io/v3/123aa110320f4aec179150fba1e1b1b1
 RLN_RELAY_ETH_CLIENT_ADDRESS=https://linea-sepolia.infura.io/v3/<key>
 
-# Account of testnet where you have Linea Sepolia ETH that would be staked into RLN contract.
-# e.g.: ETH_TESTNET_ACCOUNT=0xbecd1546a397a6bad875247d51c4c6da0e469021
-ETH_TESTNET_ACCOUNT=<YOUR_TESTNET_ACCOUNT_ADDRESS_HERE>
-
-# Private key of testnet where you have Linea Sepolia ETH that would be staked into RLN contract.
-# Note: make sure you don't use the '0x' prefix.
-# Use the following as a format example, but replace it with your own private key value
-#       e.g. ETH_TESTNET_KEY=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234
-ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
-
 # Address of the RLN contract on Linea Sepolia.
 RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
-# Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
-TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
 
-# Path and password if you have an existing RLN Membership - new membership registration is WIP
-# RLN_RELAY_CRED_PATH=""
-# RLN_RELAY_CRED_PASSWORD=""
 
 # Advanced. Can be left empty in normal use cases.
 NWAKU_IMAGE=

--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,9 @@ RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
 # Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
 TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
 
-# Password you would like to use to protect your RLN membership.
-RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"
+# Path and password if you have an existing RLN Membership - new membership registration is WIP
+# RLN_RELAY_CRED_PATH=""
+# RLN_RELAY_CRED_PASSWORD=""
 
 # Advanced. Can be left empty in normal use cases.
 NWAKU_IMAGE=

--- a/.env.example.rln
+++ b/.env.example.rln
@@ -1,0 +1,19 @@
+## RLN Credentials - EXPERIMENTAL
+## If you have/want an RLN membership to send messages
+
+# Account of testnet where you have Linea Sepolia ETH that would be staked into RLN contract.
+# e.g.: ETH_TESTNET_ACCOUNT=0xbecd1546a397a6bad875247d51c4c6da0e469021
+ETH_TESTNET_ACCOUNT=<YOUR_TESTNET_ACCOUNT_ADDRESS_HERE>
+
+# Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
+TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
+
+# Private key of testnet where you have Linea Sepolia ETH that would be staked into RLN contract.
+# Note: make sure you don't use the '0x' prefix.
+# Use the following as a format example, but replace it with your own private key value
+#       e.g. ETH_TESTNET_KEY=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234
+ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
+
+# Path and password to the keystore file
+RLN_RELAY_CRED_PATH=
+RLN_RELAY_CRED_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
 # nwaku-compose
 
-Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https://github.com/waku-org/nwaku) node for a subset of protocols (full node capability is coming soon).:
+Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https://github.com/waku-org/nwaku) node:
 
 * RLN‑enabled nwaku node (relay + store protocols, excluding message publishing)
-* Simple web UI to publish and receive messages
 * Grafana dashboard for metrics
 * Requires **Docker Compose** and **Git**
 
 ## 📝 Prerequisites
 
 * **Linea Sepolia RPC endpoint** — grab one for free on [Infura](https://www.infura.io)
-* **Linea Sepolia wallet** with at least **0.01 ETH** (Only REquired For RLN Membership Registration which is WIP)
+* **Linea Sepolia wallet** with at least **0.01 ETH** (Only Required For RLN Membership Registration which is WIP)
   * Need test ETH? Use the [Linea Sepolia faucet](https://www.infura.io/faucet/sepolia)  
   * Already have ETH on Sepolia? Bridge it to Linea via the [official bridge](https://bridge.linea.build/native-bridge)
 
 ### 🚀 Starting your node
 
-| # | Option | Quick-start command | What happens | 
-|---|------|--------------------|--------------|
-| **1** | **script** | Power user / CI | setup a .env file manually and then start the node.|
-| **2** | ** WIP setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
+| #     | Option               | Quick-start command           | What happens                                                                | 
+|-------|----------------------|-------------------------------|-----------------------------------------------------------------------------|
+| **A** | **script**           | Power user / CI               | setup a .env file manually and then start the node.                         |
+| **B** | **WIP setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
 
 <details>
-<summary>🧪 option 1 :- SCRIPT [ manual ] [ recommended ] </summary>
+<summary>🧪 option A :- SCRIPT [ manual ] [ recommended ] </summary>
 
 ```
 cp .env.example .env  
@@ -69,7 +68,6 @@ docker-compose up -d
 ###🏄🏼‍♂️ 4. Interact with your nwaku node
 
 * See [localhost:3000](http://localhost:3000/d/yns_4vFVk/nwaku-monitoring) for node metrics.
-* See [localhost:4000](http://localhost:4000) for a nice frontend to chat with other users.
 
 **📬 4. Use the REST API**
 
@@ -80,14 +78,6 @@ Your nwaku node exposes a [REST API](https://waku-org.github.io/waku-rest-api/) 
 curl http://127.0.0.1:8645/debug/v1/version
 # get nwaku info
 curl http://127.0.0.1:8645/debug/v1/info
-```
-
-**Publish a message to a `contentTopic`**. Everyone subscribed to it will receive it. Note that `payload` is base64 encoded.
-
-```
-curl -X POST "http://127.0.0.1:8645/relay/v1/auto/messages" \
- -H "content-type: application/json" \
- -d '{"payload":"'$(echo -n "Hello Waku Network - from Anonymous User" | base64)'","contentTopic":"/my-app/2/chatroom-1/proto"}'
 ```
 
 **Get messages sent to a `contentTopic`**. Note that any store node in the network is used to reply.
@@ -101,7 +91,7 @@ For advanced documentation, refer to [ADVANCED.md](https://github.com/waku-org/n
 </details>
 
 <details>
-<summary>⚙️ option 2 (not recommended at this time):- SETUP-WIZARD [ experimental ]</summary>
+<summary>⚙️ option B (not recommended at this time):- SETUP-WIZARD [ experimental ]</summary>
 
 Run the wizard script.
 Once the script is done, the node will be started for you, so there is nothing else to do.
@@ -118,8 +108,6 @@ The script is experimental, feedback and pull requests are welcome.
 RLN membership is your access key to The Waku Network. It is registered on-chain, enabling your nwaku node to send messages in a decentralized and privacy-preserving way while adhering to rate limits. Messages exceeding the rate limit will not be relayed by other peers.
 
 If you just want to relay traffic (not publish), you don't need to perform the registration.
-
-
 
 -----
 <details>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nwaku-compose
 
-Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https://github.com/waku-org/nwaku) full node:
+Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https://github.com/waku-org/nwaku) node for a subset of protocols (full node capability is coming soon).:
 
-* RLN‑enabled nwaku node (relay + store protocols)
+* RLN‑enabled nwaku node (relay + store protocols, excluding message publishing)
 * Simple web UI to publish and receive messages
 * Grafana dashboard for metrics
 * Requires **Docker Compose** and **Git**
@@ -10,7 +10,7 @@ Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https:/
 ## 📝 Prerequisites
 
 * **Linea Sepolia RPC endpoint** — grab one for free on [Infura](https://www.infura.io)
-* **Linea Sepolia wallet** with at least **0.01 ETH**  
+* **Linea Sepolia wallet** with at least **0.01 ETH** (Only REquired For RLN Membership Registration which is WIP)
   * Need test ETH? Use the [Linea Sepolia faucet](https://www.infura.io/faucet/sepolia)  
   * Already have ETH on Sepolia? Bridge it to Linea via the [official bridge](https://bridge.linea.build/native-bridge)
 
@@ -18,8 +18,8 @@ Ready‑to‑use **docker‑compose** stack for running your own [nwaku](https:/
 
 | # | Option | Quick-start command | What happens | 
 |---|------|--------------------|--------------|
-| **1** | **script** | Power user / CI | setup a .env file manually, run ./register_rln.sh, and then start the node.|
-| **2** | **setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
+| **1** | **script** | Power user / CI | setup a .env file manually and then start the node.|
+| **2** | ** WIP setup-wizard** | Fastest one-command bootstrap | Generates `.env`, registers RLN, and spins up the whole stack automatically |
 
 <details>
 <summary>🧪 option 1 :- SCRIPT [ manual ] [ recommended ] </summary>
@@ -29,10 +29,6 @@ cp .env.example .env
 ```
 Edit the .env file and fill in all required parameters 
 
-This command will register your membership and store it in `keystore/keystore.json`:
-```
-./register_rln.sh
-```
 
 ### 💽 2. Select DB Parameters
 
@@ -105,7 +101,7 @@ For advanced documentation, refer to [ADVANCED.md](https://github.com/waku-org/n
 </details>
 
 <details>
-<summary>⚙️ option 2 :- SETUP-WIZARD [ experimental ]</summary>
+<summary>⚙️ option 2 (not recommended at this time):- SETUP-WIZARD [ experimental ]</summary>
 
 Run the wizard script.
 Once the script is done, the node will be started for you, so there is nothing else to do.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,16 +143,17 @@ services:
     depends_on:
       - postgres
 
-  waku-frontend:
-   # TODO: migrate to waku-org
-   image: alrevuelta/waku-frontend:aad9628
-   ports:
-    - 127.0.0.1:4000:4000
-   restart: on-failure:5
-   depends_on:
-    - nwaku
+## Uncomment if you have RLN credentials and want to use play with a front end to send messages
+#  waku-frontend:
+#   # TODO: migrate to waku-org
+#   image: alrevuelta/waku-frontend:aad9628
+#   ports:
+#    - 127.0.0.1:4000:4000
+#   restart: on-failure:5
+#   depends_on:
+#    - nwaku
 
-##  Remove comment if you need pgadmin support in your container.
+##  Uncomment if you need pgadmin support in your container.
 ##  Commented for backward version compatibility of docker-compose.
 #   pgadmin:
 #     image: dpage/pgadmin4:latest

--- a/run_node.sh
+++ b/run_node.sh
@@ -87,8 +87,10 @@ if [ -n "${NODEKEY}" ]; then
     NODEKEY=--nodekey=${NODEKEY}
 fi
 
-RLN_RELAY_CRED_PATH=--rln-relay-cred-path=${RLN_RELAY_CRED_PATH:-/keystore/keystore.json}
-
+if [ -n "${RLN_RELAY_CRED_PATH}" ]; then
+    echo "Using RLN credentials from ${RLN_RELAY_CRED_PATH}"
+    RLN_RELAY_CRED_PATH=--rln-relay-cred-path="${RLN_RELAY_CRED_PATH}"
+fi
 
 if [ -n "${RLN_RELAY_CRED_PASSWORD}" ]; then
     RLN_RELAY_CRED_PASSWORD=--rln-relay-cred-password="${RLN_RELAY_CRED_PASSWORD}"
@@ -103,7 +105,7 @@ fi
 exec /usr/bin/wakunode\
     --relay=true\
     --filter=true\
-    --lightpush=true\
+    --lightpush=false\
     --keep-alive=true\
     --max-connections=150\
     --cluster-id=1\
@@ -126,8 +128,8 @@ exec /usr/bin/wakunode\
     --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\
     --rln-relay-eth-client-address="${RLN_RELAY_ETH_CLIENT_ADDRESS}"\
     --rln-relay-tree-path="/etc/rln_tree"\
-    "${RLN_RELAY_CRED_PATH}"\
-    "${RLN_RELAY_CRED_PASSWORD}"\
+    ${RLN_RELAY_CRED_PATH:+${RLN_RELAY_CRED_PATH}}\
+    ${RLN_RELAY_CRED_PASSWORD:+${RLN_RELAY_CRED_PASSWORD}}\
     ${DNS_WSS_CMD}\
     ${NODEKEY}\
     ${STORE_RETENTION_POLICY}\

--- a/run_node.sh
+++ b/run_node.sh
@@ -87,14 +87,20 @@ if [ -n "${NODEKEY}" ]; then
     NODEKEY=--nodekey=${NODEKEY}
 fi
 
-if [ -n "${RLN_RELAY_CRED_PATH}" ]; then
-    echo "Using RLN credentials from ${RLN_RELAY_CRED_PATH}"
-    RLN_RELAY_CRED_PATH=--rln-relay-cred-path="${RLN_RELAY_CRED_PATH}"
-fi
-
 if [ -n "${RLN_RELAY_CRED_PASSWORD}" ]; then
     RLN_RELAY_CRED_PASSWORD=--rln-relay-cred-password="${RLN_RELAY_CRED_PASSWORD}"
+    ## Enable Light Push (RLNaaS) if RLN credentials are used
+    LIGHTPUSH=--lightpush=true
+    ## Pass default value for credentials path if not set
+    RLN_RELAY_CRED_PATH=--rln-relay-cred-path=${RLN_RELAY_CRED_PATH:-/keystore/keystore.json}
+    echo "Using RLN credentials from ${RLN_RELAY_CRED_PATH}"
+else
+    LIGHTPUSH=--lightpush=false
+    # Ensure no empty values are passed
+    RLN_RELAY_CRED_PATH=""
+    RLN_RELAY_CRED_PASSWORD=""
 fi
+
 
 STORE_RETENTION_POLICY=--store-message-retention-policy=size:1GB
 
@@ -105,7 +111,7 @@ fi
 exec /usr/bin/wakunode\
     --relay=true\
     --filter=true\
-    --lightpush=false\
+    ${LIGHTPUSH}\
     --keep-alive=true\
     --max-connections=150\
     --cluster-id=1\
@@ -128,8 +134,8 @@ exec /usr/bin/wakunode\
     --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\
     --rln-relay-eth-client-address="${RLN_RELAY_ETH_CLIENT_ADDRESS}"\
     --rln-relay-tree-path="/etc/rln_tree"\
-    ${RLN_RELAY_CRED_PATH:+${RLN_RELAY_CRED_PATH}}\
-    ${RLN_RELAY_CRED_PASSWORD:+${RLN_RELAY_CRED_PASSWORD}}\
+    ${RLN_RELAY_CRED_PATH}\
+    ${RLN_RELAY_CRED_PASSWORD}\
     ${DNS_WSS_CMD}\
     ${NODEKEY}\
     ${STORE_RETENTION_POLICY}\


### PR DESCRIPTION
This is a simplification to allow nodes to be run while we have run out of memberships on the new RLN contract.

Changes:
- `run_nwaku.sh`: disable `light-push` and allow RLN_RELAY_CRED_PATH and RLN_RELAY_CRED_PASSWORD to be empty
- `.env.example`: comment out the RLN_RELAY_CRED_PASSWORD and add note about new membership registration being WIP
- `README`: remove rln registration step from option 1 and explain that new membership registration is WIP
