### PR TITLE
chore: Remove test token address and minting procedures

### DIFF
--- a/.env.example.rln
+++ b/.env.example.rln
@@ -6,7 +6,7 @@
 ETH_TESTNET_ACCOUNT=<YOUR_TESTNET_ACCOUNT_ADDRESS_HERE>
 
 # Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
-TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
+TOKEN_CONTRACT_ADDRESS=<TEST_STABLE_TOKEN_CONTRACT_ADDRESS_HERE>
 
 # Private key of testnet where you have Linea Sepolia ETH that would be staked into RLN contract.
 # Note: make sure you don't use the '0x' prefix.

--- a/register_rln.sh
+++ b/register_rln.sh
@@ -17,7 +17,7 @@ if test -n "${ETH_CLIENT_ADDRESS}"; then
   exit 1
 fi
 
-# Ensure Foundry (cast & foundryup) is available for token mint/approve calls
+# Ensure Foundry (cast & foundryup) is available for token approve calls
 if ! command -v cast >/dev/null 2>&1; then
   echo "Foundry toolkit (cast) not found. Installing Foundry..."
   curl -L https://foundry.paradigm.xyz | bash
@@ -26,42 +26,30 @@ if ! command -v cast >/dev/null 2>&1; then
   foundryup
 fi
 
-# default: do mint/approve
-NEED_MINTING=1
+# default: do approve
+NEED_APPROVAL=1
 
 for arg in "$@"; do
   case "$arg" in
-    --no-mint) NEED_MINTING=0 ;;
-    --mint)    NEED_MINTING=1 ;;
+    --no-approve) NEED_APPROVAL=0 ;;
+    --approve)    NEED_APPROVAL=1 ;;
   esac
 done
 
 RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
-TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
-TTT_AMOUNT_WEI=5000000000000000000
+TST_AMOUNT_WEI=5000000000000000000 
 
-# Mint 
-if [ "$NEED_MINTING" = "1" ]; then
-  echo "\nMinting test token"
-  if ! cast send "$TOKEN_CONTRACT_ADDRESS" "mint(address,uint256)" \
-          "$ETH_TESTNET_ACCOUNT" "$TTT_AMOUNT_WEI" \
+# Approve 
+if [ "$NEED_APPROVAL" = "1" ]; then
+  echo "Approve to spend TestStableToken"
+  if ! cast send "$TOKEN_CONTRACT_ADDRESS" "approve(address,uint256)" \
+          "$RLN_CONTRACT_ADDRESS" "$TST_AMOUNT_WEI" \
           --private-key "$ETH_TESTNET_KEY" \
           --rpc-url   "$RLN_RELAY_ETH_CLIENT_ADDRESS"
   then
-    echo " Mint transaction failed."
+    echo "Approve transaction failed."
     exit 1
   fi
-fi 
-
-# Approve 
-echo "\nApprove to spend the test tokens"
-if ! cast send "$TOKEN_CONTRACT_ADDRESS" "approve(address,uint256)" \
-        "$RLN_CONTRACT_ADDRESS" "$TTT_AMOUNT_WEI" \
-        --private-key "$ETH_TESTNET_KEY" \
-        --rpc-url   "$RLN_RELAY_ETH_CLIENT_ADDRESS"
-then
-  echo "Approve transaction failed."
-  exit 1
 fi
 
 docker run -v "$(pwd)/keystore":/keystore/:Z wakuorg/nwaku:v0.36.0 generateRlnKeystore \

--- a/setup_wizard.sh
+++ b/setup_wizard.sh
@@ -8,7 +8,7 @@ echocol()
 }
 
 RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
-TOKEN_CONTRACT_ADDRESS=0x185A0015aC462a0aECb81beCc0497b649a64B9ea
+TOKEN_CONTRACT_ADDRESS=<TEST_STABLE_TOKEN_CONTRACT_ADDRESS_HERE>
 REQUIRED_AMOUNT=5
 
 check_eth_balance() {
@@ -46,7 +46,7 @@ if [ -f keystore/keystore.json ]; then
   fi
 fi
 
-# Ensure Foundry (cast & foundryup) is available for token mint/approve calls
+# Ensure Foundry (cast & foundryup) is available for token approve calls
 if ! command -v cast >/dev/null 2>&1; then
   echocol "\n Foundry toolkit (cast) not found. Installing Foundry... \n"
   curl -L https://foundry.paradigm.xyz | bash
@@ -152,7 +152,7 @@ STORAGE_SIZE=$STORAGE_SIZE
 POSTGRES_SHM=$POSTGRES_SHM" > ./.env
 
 echocol ""
-echocol "Checking your TTT token balance..."
+echocol "Checking your TST token balance..."
 USER_BALANCE_RAW=$(cast call $TOKEN_CONTRACT_ADDRESS "balanceOf(address)(uint256)" $ETH_TESTNET_ACCOUNT --rpc-url $RLN_RELAY_ETH_CLIENT_ADDRESS 2>/dev/null)
 USER_BALANCE=$(echo "$USER_BALANCE_RAW" | awk '{print $1}')
 USER_BALANCE=$(echo "$USER_BALANCE / 10^18" | bc)
@@ -162,20 +162,20 @@ if [ -z "$USER_BALANCE" ]; then
   exit 1
 fi
 
-echocol "Your current TTT token balance is: $USER_BALANCE"
+echocol "Your current TST token balance is: $USER_BALANCE"
 echocol "Required amount: $REQUIRED_AMOUNT"
 echocol ""
 
-MINT_CHOICE="y"
+APPROVE_CHOICE="y"
 if [ "$USER_BALANCE" -ge "$REQUIRED_AMOUNT" ]; then
-  echocol "You already have enough TTT tokens to register."
-  read -p "Do you want to mint more tokens? (y/N): " MINT_CHOICE
+  echocol "You already have enough TST tokens to register."
+  read -p "Do you want to approve more tokens? (y/N): " APPROVE_CHOICE
 fi
 
-if [ "$MINT_CHOICE" = "y" ] || [ "$MINT_CHOICE" = "Y" ]; then
-  ./register_rln.sh --mint;
+if [ "$APPROVE_CHOICE" = "y" ] || [ "$APPROVE_CHOICE" = "Y" ]; then
+  ./register_rln.sh --approve;
 else
-  ./register_rln.sh --no-mint;
+  ./register_rln.sh --no-approve;
 fi
 
 echocol ""


### PR DESCRIPTION
We plan to move to a different test token contract where minting is restricted to the contract owner.
The mechanism to mint tokens have been removed from `register_rln.sh` as well as `setup_wizard`.
The address of the new token contract will need to be added in the .env file or in the `setup_wizard` script to be able to approve once minted tokens have been transferred to an account.