### PR TITLE
chore: Add missing variable for eth client address and examples for rln cred

### DIFF
--- a/.env.example.rln
+++ b/.env.example.rln
@@ -1,6 +1,10 @@
 ## RLN Credentials - EXPERIMENTAL
 ## If you have/want an RLN membership to send messages
 
+# RPC URL for accessing testnet via HTTP.
+# e.g. https://linea-sepolia.infura.io/v3/123aa110320f4aec179150fba1e1b1b1
+RLN_RELAY_ETH_CLIENT_ADDRESS=https://linea-sepolia.infura.io/v3/<key>
+
 # Account of testnet where you have Linea Sepolia ETH that would be staked into RLN contract.
 # e.g.: ETH_TESTNET_ACCOUNT=0xbecd1546a397a6bad875247d51c4c6da0e469021
 ETH_TESTNET_ACCOUNT=<YOUR_TESTNET_ACCOUNT_ADDRESS_HERE>
@@ -14,6 +18,7 @@ TOKEN_CONTRACT_ADDRESS=<TEST_STABLE_TOKEN_CONTRACT_ADDRESS_HERE>
 #       e.g. ETH_TESTNET_KEY=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234
 ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
 
-# Path and password to the keystore file
-RLN_RELAY_CRED_PATH=
-RLN_RELAY_CRED_PASSWORD=
+# Path where you would like to store your RLN keystore file
+RLN_RELAY_CRED_PATH="/keystore.jeystore.json"
+# Password you would like to use to protect your RLN membership.
+RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"

--- a/.env.example.rln
+++ b/.env.example.rln
@@ -19,6 +19,6 @@ TOKEN_CONTRACT_ADDRESS=<TEST_STABLE_TOKEN_CONTRACT_ADDRESS_HERE>
 ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
 
 # Path where you would like to store your RLN keystore file
-RLN_RELAY_CRED_PATH="/keystore.jeystore.json"
+RLN_RELAY_CRED_PATH="/keystore.keystore.json"
 # Password you would like to use to protect your RLN membership.
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"

--- a/.env.example.rln
+++ b/.env.example.rln
@@ -19,6 +19,6 @@ TOKEN_CONTRACT_ADDRESS=<TEST_STABLE_TOKEN_CONTRACT_ADDRESS_HERE>
 ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
 
 # Path where you would like to store your RLN keystore file
-RLN_RELAY_CRED_PATH="/keystore.keystore.json"
+RLN_RELAY_CRED_PATH="/keystore/keystore.json"
 # Password you would like to use to protect your RLN membership.
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"


### PR DESCRIPTION
This PR updates the `.env.example.rln` to make it more complete.
Added :
- `RLN_RELAY_ETH_CLIENT_ADDRESS`
- default value for `RLN_RELAY_CRED_PATH`
- example value for `RLN_RELAY_CRED_PASSWORD`