### PR TITLE
chore: Update the TOKEN_CONTRACT_ADDRESS in the dogfooding .env

### DIFF
--- a/dogfooding/.env.example.publisher
+++ b/dogfooding/.env.example.publisher
@@ -20,7 +20,7 @@ ETH_TESTNET_KEY=<YOUR_TESTNET_PRIVATE_KEY_HERE>
 RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
 
 # Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
-TOKEN_CONTRACT_ADDRESS=0xd17e184e3c1941585a3edcb3a10367da6326d844
+TOKEN_CONTRACT_ADDRESS=0xd28d1a688b1cBf5126fB8B034d0150C81ec0024c
 
 # Password you would like to use to protect your RLN membership.
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"


### PR DESCRIPTION
A new TestStableToken with added Minter-Role functionality has been deployed as well as a proxy contract to point to this contract.
The contract address for the TestStableToken needs to be updated to the TST Proxy contract.