### PR TITLE
enable peer exchange service by default

### DIFF
--- a/run_node.sh
+++ b/run_node.sh
@@ -111,6 +111,7 @@ fi
 exec /usr/bin/wakunode\
     --relay=true\
     --filter=true\
+    --peer-exchange=true\
     ${LIGHTPUSH}\
     --keep-alive=true\
     --max-connections=150\


### PR DESCRIPTION
Noticed that peer-exchange is not enabled by default in nwaku-compose. Peer-Exchange is a very useful difscovery metho for light nodes to discover peers quickly and it puts almost no load on service-nodes which already get peers via discv5. 

Enabling this by default would make every nwaku node runner support this protocol.

cc @Ivansete-status Not sure if this is enabled in the prod fleet, if not we should update the fleet as well.