### PR TITLE
chore: rln_tree deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .env
 keystore
 postgresql
-rln_tree
 .env

--- a/FAQ.md
+++ b/FAQ.md
@@ -30,7 +30,7 @@ Your node should have at least 40 connected peers, and you should see some traff
 
 ### My node is not able to start properly
 If you are using Contabo, we recommend moving to a different VPS vendor.
-If not, remove the keystore and rln_tree folders, run the ./register_rln script again, and try to run your node again.
+If not, remove the `keystore` folder, run the `./register_rln.sh` script again, and try to run your node again.
 
 ### Does running a node have any incentives?
 There are currently no incentives in place, but it's something currently being researched and designed.

--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Please review the latest https://github.com/waku-org/nwaku-compose/blob/master/.
 
 Also, move your Sepolia RPC client (e.g., Infura) to a Linea Sepolia RPC client.
 
-You will need to delete both the `keystore` and `rln_tree` folders, and register your membership again before using the new version by running the following commands:
+You will need to delete the `keystore` folder and register your membership again before using the new version by running the following commands:
 
 1. `cd nwaku-compose` ( go into the root's repository folder )
 2. `docker-compose down`
-3. `sudo rm -r keystore rln_tree`
+3. `sudo rm -r keystore`
 4. `git pull origin master`
 5. `./register_rln.sh`
 6. `docker-compose up -d`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,6 @@ services:
     volumes:
       - ./run_node.sh:/opt/run_node.sh:Z
       - ${CERTS_DIR:-./certs}:/etc/letsencrypt/:Z
-      - ./rln_tree:/etc/rln_tree/:Z
       - ./keystore:/keystore:Z
     entrypoint: sh
     command:

--- a/run_node.sh
+++ b/run_node.sh
@@ -134,7 +134,6 @@ exec /usr/bin/wakunode\
     --store=true\
     --store-message-db-url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/postgres"\
     --rln-relay-eth-client-address="${RLN_RELAY_ETH_CLIENT_ADDRESS}"\
-    --rln-relay-tree-path="/etc/rln_tree"\
     ${RLN_RELAY_CRED_PATH}\
     ${RLN_RELAY_CRED_PASSWORD}\
     ${DNS_WSS_CMD}\


### PR DESCRIPTION
After post-sync, rln_tree is no longer needed, so it’s being deprecated. 