### PR TITLE
Add info for dogfooding to mint tokens with burning ETH method

### DIFF
--- a/dogfooding/.env.example.publisher
+++ b/dogfooding/.env.example.publisher
@@ -22,6 +22,9 @@ RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
 # Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
 TOKEN_CONTRACT_ADDRESS=0xd28d1a688b1cBf5126fB8B034d0150C81ec0024c
 
+# Amount of ETH to send with the minting transaction to obtain RLN membership tokens. e.g. use value of 5000000000000000000 (wei) for 5 tokens
+ETH_AMOUNT=<ETH_AMOUNT>
+
 # Password you would like to use to protect your RLN membership.
 RLN_RELAY_CRED_PASSWORD="my_secure_keystore_password"
 

--- a/dogfooding/.env.example.publisher
+++ b/dogfooding/.env.example.publisher
@@ -22,7 +22,7 @@ RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
 # Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
 TOKEN_CONTRACT_ADDRESS=0xd28d1a688b1cBf5126fB8B034d0150C81ec0024c
 
-# Amount of ETH to send with the minting transaction to obtain RLN membership tokens. 
+# Amount of Linea Sepolia ETH to send with the minting transaction to obtain RLN membership tokens. 
 # Conversion rate is 1:1 (1 ETH = 1 token). e.g. use value of 5000000000000000000 (wei) for 5 tokens (5 ETH)
 ETH_AMOUNT=<ETH_AMOUNT>
 

--- a/dogfooding/.env.example.publisher
+++ b/dogfooding/.env.example.publisher
@@ -22,7 +22,8 @@ RLN_CONTRACT_ADDRESS=0xB9cd878C90E49F797B4431fBF4fb333108CB90e6
 # Address of the RLN Membership Token contract on Linea Sepolia used to pay for membership.
 TOKEN_CONTRACT_ADDRESS=0xd28d1a688b1cBf5126fB8B034d0150C81ec0024c
 
-# Amount of ETH to send with the minting transaction to obtain RLN membership tokens. e.g. use value of 5000000000000000000 (wei) for 5 tokens
+# Amount of ETH to send with the minting transaction to obtain RLN membership tokens. 
+# Conversion rate is 1:1 (1 ETH = 1 token). e.g. use value of 5000000000000000000 (wei) for 5 tokens (5 ETH)
 ETH_AMOUNT=<ETH_AMOUNT>
 
 # Password you would like to use to protect your RLN membership.

--- a/dogfooding/dogfood_readme.md
+++ b/dogfooding/dogfood_readme.md
@@ -9,7 +9,12 @@
     ```
     cp dogfooding/.env.example.publisher .env
     ```
-2. Obtain test tokens (if needed, request in Discord).
+2. Obtain test tokens.   
+    The total tokens minted is determined by the amount of ETH sent with the transaction.
+
+    ```
+    cast send $TOKEN_CONTRACT_ADDRESS "mintWithETH(address)" $ETH_TESTNET_ACCOUNT --value $ETH_AMOUNT --rpc-url $RLN_RELAY_ETH_CLIENT_ADDRESS --private-key $ETH_TESTNET_KEY --from $ETH_TESTNET_ACCOUNT
+    ```
 3. Run the RLN registration script:
 
     ```

--- a/dogfooding/dogfood_readme.md
+++ b/dogfooding/dogfood_readme.md
@@ -13,7 +13,7 @@
     The total tokens minted is determined by the amount of ETH sent with the transaction.
 
     ```
-    cast send $TOKEN_CONTRACT_ADDRESS "mintWithETH(address)" $ETH_TESTNET_ACCOUNT --value $ETH_AMOUNT --rpc-url $RLN_RELAY_ETH_CLIENT_ADDRESS --private-key $ETH_TESTNET_KEY --from $ETH_TESTNET_ACCOUNT
+    cast send $TOKEN_CONTRACT_ADDRESS "mintWithETH(address)" $ETH_TESTNET_ACCOUNT --value $ETH_AMOUNT --rpc-url $RLN_RELAY_ETH_CLIENT_ADDRESS --private-key $ETH_TESTNET_KEY
     ```
 3. Run the RLN registration script:
 

--- a/dogfooding/dogfood_readme.md
+++ b/dogfooding/dogfood_readme.md
@@ -9,7 +9,7 @@
     ```
     cp dogfooding/.env.example.publisher .env
     ```
-2. Obtain test tokens.   
+2. Obtain test tokens.
     The total tokens minted is determined by the amount of ETH sent with the transaction.
 
     ```


### PR DESCRIPTION
This PR adds dogfooding information for the updated TST contract.
The dogfood_readme.md provides the command to mint tokens by burning ETH for accounts that are not whitelisted.